### PR TITLE
Feat/rag

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -11,7 +11,8 @@ exclude =
     dist,
     build,
     *.egg-info,
-    egile_mcp_starter/template
+    egile_mcp_starter/template,
+    egile_mcp_starter/templates
 extend-ignore = E203, W503
 select = E,W,F,C
 per-file-ignores =

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
           include_examples: "y"
           server_type: "tools"
         EOF
-        poetry run egile-mcp-starter --output-dir . --config-file test-config.yaml --no-input
+        poetry run egile-mcp-starter --project-name "test_tools_server" --output-dir . --config-file test-config.yaml --no-input
         ls -la test_tools_server/
     
     - name: Test generated project structure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Template directories organized under `egile_mcp_starter/templates/`
 - **Documentation Structure**: Reorganized documentation
   - Consolidated plugin architecture docs into main documentation
-  - Removed standalone `PLUGIN_ARCHITECTURE.md`
   - Integrated template information into README and docs
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Enhanced CLI**: Extended command-line interface with template selection
   - `--template` option to choose between available templates (mcp, rag)
   - `--list-templates` option to display all available templates
+  - `--project-name` option to override project name and directory structure
   - Dynamic template validation and error handling
   - Improved help messages and user guidance
 - **Comprehensive Documentation**: 
@@ -53,6 +54,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Template path resolution in different environments
 - Test compatibility with new plugin architecture
 - Error handling for invalid template selections
+- Project slug generation in template plugins when project name is overridden
+- Plugin system context handling for custom project names
 
 ### Technical Details
 - Plugin system supports hooks for pre/post generation processing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,62 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2025-07-29
+
+### Added
+- **Plugin Architecture**: Implemented extensible plugin system for template management
+  - Abstract `TemplatePlugin` base class for creating custom templates
+  - `TemplateRegistry` for plugin discovery and management
+  - Built-in plugin discovery for templates in `egile_mcp_starter/plugins/builtin/`
+  - Support for external plugin registration
+- **RAG Template**: New template for Retrieval-Augmented Generation (RAG) applications
+  - Multiple vector database support: Chroma, Pinecone, Weaviate, Qdrant, FAISS
+  - Multiple embedding models: Sentence Transformers, OpenAI, Cohere
+  - Document processing capabilities (PDF, text, web scraping)
+  - Configurable chunking strategies and retrieval methods
+  - Advanced search capabilities with filtering and metadata
+- **Enhanced CLI**: Extended command-line interface with template selection
+  - `--template` option to choose between available templates (mcp, rag)
+  - `--list-templates` option to display all available templates
+  - Dynamic template validation and error handling
+  - Improved help messages and user guidance
+- **Comprehensive Documentation**: 
+  - New `docs/templates.md` with plugin development guide
+  - Updated README with streamlined content (reduced from 629 to 264 lines)
+  - Template-specific documentation and examples
+  - Plugin architecture best practices
+- **Testing Suite**: Complete test coverage for plugin system
+  - 28+ test methods covering all plugin functionality
+  - Unit tests for template plugins, registry, and generator integration
+  - Integration tests for end-to-end workflows
+  - Mock-based testing for isolated component testing
+
+### Changed
+- **Generator Architecture**: Refactored `MCPProjectGenerator` to use plugin system
+  - Template selection now handled through registry
+  - Context generation delegated to template plugins
+  - Backward compatibility maintained with original MCP template
+- **Template Organization**: Restructured template system
+  - Original template moved to `egile_mcp_starter/plugins/builtin/mcp_template.py`
+  - New RAG template in `egile_mcp_starter/plugins/builtin/rag_template.py`
+  - Template directories organized under `egile_mcp_starter/templates/`
+- **Documentation Structure**: Reorganized documentation
+  - Consolidated plugin architecture docs into main documentation
+  - Removed standalone `PLUGIN_ARCHITECTURE.md`
+  - Integrated template information into README and docs
+
+### Fixed
+- CLI output formatting for project path handling
+- Template path resolution in different environments
+- Test compatibility with new plugin architecture
+- Error handling for invalid template selections
+
+### Technical Details
+- Plugin system supports hooks for pre/post generation processing
+- Template validation with customizable context requirements
+- Dependency computation for RAG templates based on selected features
+- Registry-based plugin discovery with automatic loading
+- Comprehensive error handling and user-friendly messages
 
 ## [0.1.0] - 2025-07-28
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ A comprehensive cookiecutter template for creating Model Context Protocol (MCP) 
 
 - 🚀 **Modern Python Setup**: Uses Poetry for dependency management and packaging
 - 🏗️ **FASTMCP Framework**: Built on the efficient FASTMCP framework for MCP servers
-- 🛠️ **Flexible Server Types**: Choose from tools, resources, prompts, or full-featured servers
+- � **Plugin Architecture**: Extensible template system with multiple server types
+- 🛠️ **Multiple Templates**: Choose from MCP, RAG, or custom templates
 - 🧪 **Testing Ready**: Comprehensive test suite with pytest and coverage
 - 🔧 **Development Tools**: Pre-configured with Black, Flake8, MyPy, and pre-commit hooks
 - 🐳 **Docker Support**: Optional Docker configuration for easy deployment
@@ -44,24 +45,65 @@ poetry install
 ### Generate a New MCP Server
 
 ```bash
-# Using the installed command
+# Using the installed command (default MCP template)
 egile-mcp-starter
 
 # Or if installed from source
 poetry run egile-mcp-starter
 
+# Choose a specific template
+egile-mcp-starter --template rag
+
+# List available templates
+egile-mcp-starter --list-templates
+
 # With options
-egile-mcp-starter --output-dir ./my-projects --verbose
+egile-mcp-starter --template rag --output-dir ./my-projects --verbose
 ```
 
-### Available Server Types
+### Available Templates
 
-When generating a project, you can choose from:
+The egile-mcp-starter uses a **plugin architecture** that supports multiple project templates. Choose the template that best fits your needs:
 
-- **tools**: Server with tool implementations for AI interactions
-- **resources**: Server with resource management for data access  
-- **prompts**: Server with prompt templates for AI guidance
-- **full**: Complete server with all capabilities (tools, resources, and prompts)
+#### 🔧 MCP Template (default)
+The standard MCP server template with comprehensive features:
+- **Server Types**: Tools, resources, prompts, or full-featured servers
+- **FASTMCP Integration**: Built on the efficient FASTMCP framework
+- **Development Ready**: Testing, linting, CI/CD, Docker support
+- **Flexible Configuration**: YAML-based config with environment variables
+
+```bash
+egile-mcp-starter --template mcp
+```
+
+#### 🧠 RAG Template
+Advanced RAG-enabled MCP server with vector search capabilities:
+- **Vector Databases**: Chroma, Pinecone, Weaviate, Qdrant support
+- **Embedding Models**: Sentence Transformers, OpenAI, Cohere
+- **Document Processing**: PDF, DOCX, Excel, text files
+- **Web Scraping**: Optional web page scraping and indexing
+- **Chunking Strategies**: Recursive, semantic, fixed-size
+- **Reranking**: Optional result reranking for better relevance
+- **MCP Tools**: `ingest_documents`, `search_documents`, `scrape_and_index`
+- **MCP Resources**: Document listing, metadata access, chunk search
+
+```bash
+egile-mcp-starter --template rag
+```
+
+#### 🔌 Plugin System Features
+- **Extensible**: Easy to add new templates without modifying core code
+- **External Plugins**: Third-party templates via entry points
+- **Template Hooks**: Pre/post-generation customization
+- **Backward Compatible**: Original functionality preserved
+
+```bash
+# List all available templates
+egile-mcp-starter --list-templates
+
+# Generate with specific template and options
+egile-mcp-starter --template rag --output-dir ./my-projects --verbose
+```
 
 ## Generated Project Structure
 
@@ -85,6 +127,56 @@ my-mcp-server/
 ├── Dockerfile               # Docker configuration (optional)
 └── .github/workflows/       # CI/CD workflows (optional)
 ```
+
+## Extending the Plugin System
+
+### Adding Custom Templates
+
+The plugin architecture makes it easy to add new templates:
+
+1. **Create a Template Plugin**:
+```python
+from egile_mcp_starter import TemplatePlugin
+from pathlib import Path
+
+class MyTemplatePlugin(TemplatePlugin):
+    def __init__(self):
+        super().__init__(
+            name="my_template",
+            description="My custom MCP server template",
+            version="1.0.0"
+        )
+    
+    def get_template_path(self) -> Path:
+        return Path(__file__).parent / "my_template"
+    
+    def get_default_context(self) -> dict:
+        return {"project_name": "My Custom Server"}
+```
+
+2. **Register the Plugin**:
+```python
+from egile_mcp_starter import get_registry
+
+registry = get_registry()
+registry.register(MyTemplatePlugin())
+```
+
+3. **External Plugin Distribution**:
+```python
+# In your package's setup.py or pyproject.toml
+entry_points = {
+    'egile_mcp_starter.templates': [
+        'my_template = my_package.my_template:MyTemplatePlugin',
+    ],
+}
+```
+
+### Template Hooks
+
+Customize the generation process with hooks:
+- **Pre-generation**: Modify context, validate inputs, compute dependencies
+- **Post-generation**: Initialize databases, download models, set up git repos
 
 ## Development
 
@@ -131,26 +223,13 @@ poetry run mypy egile_mcp_starter
 poetry run pre-commit run --all-files
 ```
 
-## Configuration Options
+## Documentation
 
-The cookiecutter template supports these configuration options:
+For detailed information about templates and the plugin system, see:
 
-| Option | Description | Choices |
-|--------|-------------|---------|
-| `project_name` | Display name for your project | String |
-| `project_slug` | Python package name | Auto-generated |
-| `project_description` | Project description | String |
-| `author_name` | Your name | String |
-| `author_email` | Your email | String |
-| `github_username` | Your GitHub username | String |
-| `version` | Initial version | String (default: 0.1.0) |
-| `python_version` | Python version | 3.10, 3.11, 3.12 |
-| `use_docker` | Include Docker support | y/n |
-| `use_github_actions` | Include CI/CD workflows | y/n |
-| `use_pre_commit` | Include pre-commit hooks | y/n |
-| `license` | Project license | MIT, Apache-2.0, GPL-3.0, BSD-3-Clause, None |
-| `include_examples` | Include example implementations | y/n |
-| `server_type` | Type of MCP server | tools, resources, prompts, full |
+- **[Templates Guide](docs/templates.md)**: Comprehensive documentation on available templates, the plugin architecture, and how to create custom templates
+- **[Configuration](docs/configuration.md)**: Detailed configuration options for each template
+- **[API Reference](docs/api_reference.md)**: Complete API documentation
 
 ## Contributing
 
@@ -173,370 +252,6 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 - 🐛 Issues: [GitHub Issues](https://github.com/jpoullet2000/egile-mcp-starter/issues)
 - 📖 MCP Documentation: [Model Context Protocol](https://modelcontextprotocol.io/)
 - 🚀 FASTMCP: [FASTMCP Framework](https://github.com/jlowin/fastmcp)
-
----
-
-Built with ❤️ using [FASTMCP](https://github.com/jlowin/fastmcp) and the [Model Context Protocol](https://modelcontextprotocol.io/)
-
-## Overview
-
-The Model Context Protocol (MCP) is a standardized protocol for communication between AI systems and external tools/data sources. This template provides a complete foundation for building MCP servers with:
-
-- 🛠️ **Tool Support** - Implement custom tools that AI can call
-- 📚 **Resource Support** - Provide data and information access
-- 💬 **Prompt Support** - Create reusable prompt templates
-- 🧪 **Testing Framework** - Comprehensive test coverage
-- 🔧 **Development Tools** - Linting, formatting, type checking
-- 🐳 **Docker Support** - Container deployment ready
-- 🔄 **CI/CD Pipeline** - GitHub Actions integration
-- 📋 **Type Safety** - Full type annotations throughout
-
-## Features
-
-### 🎯 **Template Options**
-
-- **Server Types**: Choose from tools, resources, prompts, or full MCP server
-- **Python Versions**: Support for Python 3.10-3.12
-- **Docker Integration**: Optional Docker and docker-compose setup
-- **CI/CD Ready**: GitHub Actions workflow included
-- **Development Tools**: Pre-commit hooks, linting, testing
-- **Documentation**: Auto-generated README and examples
-
-### 🛠️ **Built-in Capabilities**
-
-- **Configuration Management**: YAML-based config with environment variable override
-- **Logging**: Structured logging with configurable levels
-- **Error Handling**: Comprehensive error handling and validation
-- **Type Safety**: Full type annotations with mypy checking
-- **Testing**: pytest-based testing with coverage reporting
-- **Security**: Built-in security scanning and best practices
-
-## Quick Start
-
-### Installation
-
-```bash
-# Install the package
-pip install egile-mcp-starter
-
-# Or install from source
-git clone https://github.com/jpoullet2000/egile-mcp-starter.git
-cd egile-mcp-starter
-pip install -e .
-```
-
-### Generate a New MCP Server
-
-```bash
-# Use the CLI tool
-egile-mcp-starter
-
-# Or use cookiecutter directly
-cookiecutter https://github.com/jpoullet2000/egile-mcp-starter.git
-```
-
-### Interactive Configuration
-
-The template will prompt you for:
-
-- **Project name and description**
-- **Author information**
-- **Server type** (tools, resources, prompts, or full)
-- **Python version** (3.10-3.12)
-- **Optional features** (Docker, GitHub Actions, pre-commit)
-- **License choice** (MIT, Apache-2.0, GPL-3.0, BSD-3-Clause, or None)
-
-### Example Usage
-
-```bash
-$ egile-mcp-starter
-project_name [My MCP Server]: Weather MCP Server
-project_description [A Model Context Protocol server built with FASTMCP]: Weather data MCP server with forecast tools
-author_name [Your Name]: John Doe
-author_email [your.email@example.com]: john@example.com
-server_type [full]: tools
-python_version [3.11]: 3.11
-use_docker [y]: y
-use_github_actions [y]: y
-include_examples [y]: y
-
-✅ MCP server project generated successfully at: ./weather_mcp_server
-```
-
-## Generated Project Structure
-
-```
-my_mcp_server/
-├── src/
-│   ├── my_mcp_server/
-│   │   ├── __init__.py
-│   │   ├── server.py          # Main MCP server
-│   │   ├── config.py          # Configuration management
-│   │   ├── tools/             # Tool implementations
-│   │   ├── resources/         # Resource handlers
-│   │   ├── prompts/           # Prompt templates
-│   │   └── utils.py           # Utility functions
-│   └── main.py                # Entry point
-├── tests/                     # Test suite
-├── Dockerfile                 # Docker configuration
-├── docker-compose.yml         # Docker Compose setup
-├── .github/workflows/ci.yml   # GitHub Actions CI/CD
-├── .pre-commit-config.yaml    # Pre-commit hooks
-├── pyproject.toml             # Project configuration
-├── poetry.lock                # Locked dependencies
-└── README.md                  # Project documentation
-```
-
-## Development Workflow
-
-### 1. Generate Your Project
-
-```bash
-egile-mcp-starter
-cd your-project-name
-```
-
-### 2. Set Up Development Environment
-
-```bash
-# Install dependencies
-pip install -e ".[dev]"
-
-# Set up pre-commit hooks (if enabled)
-pre-commit install
-```
-
-### 3. Customize Your Server
-
-- **Add Tools**: Implement in `src/your_project/tools/`
-- **Add Resources**: Implement in `src/your_project/resources/`
-- **Add Prompts**: Implement in `src/your_project/prompts/`
-- **Configure**: Edit `config.example.yaml`
-
-### 4. Test and Deploy
-
-```bash
-# Run tests
-pytest
-
-# Run with Docker
-docker-compose up
-
-# Deploy
-git push origin main  # Triggers CI/CD
-```
-
-## Example Server Types
-
-### 🛠️ Tools Server
-
-```python
-@server.tool("weather_forecast")
-async def get_weather(location: str, days: int = 5) -> dict:
-    """Get weather forecast for a location."""
-    # Your implementation here
-    return {"location": location, "forecast": [...]}
-```
-
-### 📚 Resources Server
-
-```python
-@server.resource("weather://current")
-async def current_weather() -> str:
-    """Provide current weather data."""
-    # Your implementation here
-    return json.dumps(weather_data)
-```
-
-### 💬 Prompts Server
-
-```python
-@server.prompt("weather_analysis")
-async def weather_analysis_prompt(data: str) -> str:
-    """Generate weather analysis prompt."""
-    return f"""Analyze this weather data and provide insights:
-    
-{data}
-
-Please provide:
-1. Current conditions summary
-2. Notable weather patterns
-3. Recommendations for activities
-"""
-```
-
-## Configuration Options
-
-The generated project includes extensive configuration options:
-
-```yaml
-# Server settings
-host: localhost
-port: 8000
-log_level: INFO
-
-# Feature toggles
-enable_tools: true
-enable_resources: true
-enable_prompts: true
-
-# Custom settings
-custom_settings:
-  debug_mode: false
-  max_concurrent_requests: 10
-  # Add your custom options here
-```
-
-## CLI Usage
-
-```bash
-# Generate with defaults
-egile-mcp-starter --no-input
-
-# Use custom config file
-egile-mcp-starter --config-file my-config.yaml
-
-# Specify output directory
-egile-mcp-starter --output-dir ./projects/
-
-# Verbose output
-egile-mcp-starter --verbose
-```
-
-## Integration with Claude Desktop
-
-### Option 1: Direct Python Execution
-
-Add your generated server to Claude Desktop configuration:
-
-```json
-{
-  "mcpServers": {
-    "your-server-name": {
-      "command": "python",
-      "args": ["/path/to/your-project/src/main.py"],
-      "env": {
-        "LOG_LEVEL": "INFO"
-      }
-    }
-  }
-}
-```
-
-### Option 2: Using Docker
-
-For containerized deployment, you can use the Docker image:
-
-```json
-{
-  "mcpServers": {
-    "your-server-name": {
-      "command": "docker",
-      "args": [
-        "run", "--rm", "-i",
-        "-v", "/path/to/your/config:/app/config",
-        "jpoullet2000/egile-mcp-starter"
-      ],
-      "env": {
-        "LOG_LEVEL": "INFO"
-      }
-    }
-  }
-}
-```
-
-Note: Replace `/path/to/your/config` with the actual path to your server's configuration files.
-
-## Contributing
-
-1. Fork the repository
-2. Create a feature branch (`git checkout -b feature/amazing-feature`)
-3. Make your changes
-4. Run tests (`poetry run pytest`)
-5. Run code quality checks (`poetry run black . && poetry run flake8 . && poetry run mypy egile_mcp_starter`)
-6. Commit your changes (`git commit -m 'Add amazing feature'`)
-7. Push to the branch (`git push origin feature/amazing-feature`)
-8. Open a Pull Request
-
-### Development Setup
-
-```bash
-# Clone the repository
-git clone https://github.com/jpoullet2000/egile-mcp-starter.git
-cd egile-mcp-starter
-
-# Install with Poetry
-poetry install
-
-# Install pre-commit hooks
-poetry run pre-commit install
-
-# Run tests
-poetry run pytest
-
-# Run all quality checks
-poetry run black .
-poetry run flake8 .
-poetry run mypy egile_mcp_starter
-poetry run pytest --cov=egile_mcp_starter
-```
-
-### CI/CD Pipeline
-
-The project includes a comprehensive CI/CD pipeline with GitHub Actions that:
-
-- **Testing**: Runs tests across Python 3.10, 3.11, and 3.12
-- **Code Quality**: Checks formatting (Black), linting (Flake8), type hints (MyPy), and import sorting (isort)
-- **Security**: Scans dependencies with Safety and code with Bandit
-- **Template Testing**: Validates that generated projects work correctly
-- **Docker**: Builds multi-platform Docker images
-- **Publishing**: Automatically publishes to PyPI on releases
-
-The pipeline runs on:
-- Every push to `main` and `develop` branches
-- Every pull request to `main`
-- Every release
-
-### Docker Support
-
-Build and run the project in Docker:
-
-```bash
-# Build the image
-docker build -t egile-mcp-starter .
-
-# Run interactively
-docker run -it --rm -v $(pwd)/output:/app/output egile-mcp-starter
-
-# Generate a project
-docker run -it --rm -v $(pwd)/output:/app/output egile-mcp-starter \
-  --output-dir /app/output --no-input
-```
-
-## Roadmap
-
-- [ ] Additional server templates (database, API gateway, etc.)
-- [ ] Integration with more MCP client libraries
-- [ ] Advanced monitoring and observability features
-- [ ] Plugin system for extensibility
-- [ ] GUI-based project generator
-
-## Requirements
-
-- Python 3.10+
-- cookiecutter
-- Git (for project initialization)
-
-## License
-
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
-
-## Support
-
-- 📧 **Email**: jpoullet2000@gmail.com
-- 🐛 **Issues**: [GitHub Issues](https://github.com/jpoullet2000/egile-mcp-starter/issues)
-- 📖 **MCP Documentation**: [Model Context Protocol](https://modelcontextprotocol.io/)
-- 🚀 **FASTMCP**: [FASTMCP Framework](https://github.com/jlowin/fastmcp)
 
 ## Acknowledgments
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ egile-mcp-starter --template mcp
 
 #### 🧠 RAG Template
 Advanced RAG-enabled MCP server with vector search capabilities:
-- **Vector Databases**: Chroma, Pinecone, Weaviate, Qdrant support
+- **Vector Databases**: Chroma, Pinecone, Weaviate, Qdrant, FAISS support
 - **Embedding Models**: Sentence Transformers, OpenAI, Cohere
 - **Document Processing**: PDF, DOCX, Excel, text files
 - **Web Scraping**: Optional web page scraping and indexing

--- a/README.md
+++ b/README.md
@@ -57,8 +57,40 @@ egile-mcp-starter --template rag
 # List available templates
 egile-mcp-starter --list-templates
 
-# With options
-egile-mcp-starter --template rag --output-dir ./my-projects --verbose
+# With custom project name
+egile-mcp-starter --project-name "my_custom_server"
+
+# With multiple options
+egile-mcp-starter --template rag --output-dir ./my-projects --project-name "my_rag_server" --verbose
+```
+
+### CLI Options
+
+The `egile-mcp-starter` command supports the following options:
+
+| Option | Short | Description | Example |
+|--------|-------|-------------|---------|
+| `--template` | `-t` | Choose the template to use | `--template rag` |
+| `--project-name` | | Override the project name (affects directory and package name) | `--project-name "my_server"` |
+| `--output-dir` | `-o` | Output directory for the generated project | `--output-dir ./projects` |
+| `--list-templates` | | List all available templates and exit | `--list-templates` |
+| `--verbose` | `-v` | Print detailed status information | `--verbose` |
+| `--no-input` | | Don't prompt for parameters, use defaults | `--no-input` |
+| `--config-file` | | Path to cookiecutter config file | `--config-file config.yaml` |
+| `--default-config` | | Use default values for all template variables | `--default-config` |
+| `--help` | | Show help message and exit | `--help` |
+
+**Examples:**
+
+```bash
+# Generate with custom name and template
+egile-mcp-starter --template rag --project-name "my_awesome_rag_server"
+
+# Non-interactive generation for CI/CD
+egile-mcp-starter --no-input --project-name "test_server" --output-dir ./build
+
+# List available templates
+egile-mcp-starter --list-templates
 ```
 
 ### Available Templates
@@ -102,7 +134,7 @@ egile-mcp-starter --template rag
 egile-mcp-starter --list-templates
 
 # Generate with specific template and options
-egile-mcp-starter --template rag --output-dir ./my-projects --verbose
+egile-mcp-starter --template rag --output-dir ./my-projects --project-name "my_rag_server" --verbose
 ```
 
 ## Generated Project Structure

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -40,6 +40,30 @@ Use it with:
 egile-mcp-starter --config-file my-config.yaml --no-input
 ```
 
+### CLI Option Overrides
+
+You can override specific configuration values using command-line options, even when using a configuration file:
+
+```bash
+# Override project name via CLI
+egile-mcp-starter --config-file my-config.yaml --project-name "custom_server_name" --no-input
+
+# Quick generation with minimal CLI options
+egile-mcp-starter --project-name "my_api_server" --template mcp --no-input
+
+# Override output directory
+egile-mcp-starter --project-name "test_server" --output-dir ./build --no-input
+```
+
+**Available CLI Overrides:**
+- `--project-name`: Override the project name (affects directory and package names)
+- `--template`: Choose the template (`mcp`, `rag`)  
+- `--output-dir`: Specify output directory
+- `--verbose`: Enable detailed output
+
+The CLI overrides take precedence over configuration file values.
+```
+
 ## Configuration Options
 
 ### Project Information

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,7 @@ A comprehensive cookiecutter template for creating Model Context Protocol (MCP) 
 
 installation
 quickstart
+templates
 configuration
 server_types
 api_reference

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,8 +29,9 @@ egile-mcp-starter is a comprehensive cookiecutter template that helps you quickl
 ## Key Features
 
 - 🚀 **Modern Python Setup**: Uses Poetry for dependency management and packaging
-- 🏗️ **FASTMCP Framework**: Built on the efficient FASTMCP framework for MCP servers
-- 🛠️ **Flexible Server Types**: Choose from tools, resources, prompts, or full-featured servers
+- 🏗️ **FASTMCP Framework**: Built on the efficient FASTMCP framework for MCP servers  
+- � **Plugin Architecture**: Extensible template system with multiple server types
+- 🧠 **RAG Template**: Advanced template with vector database support (Chroma, Pinecone, Weaviate, Qdrant, FAISS)
 - 🧪 **Testing Ready**: Comprehensive test suite with pytest and coverage
 - 🔧 **Development Tools**: Pre-configured with Black, Flake8, MyPy, and pre-commit hooks
 - 🐳 **Docker Support**: Optional Docker configuration for easy deployment

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -52,6 +52,34 @@ EOF
 egile-mcp-starter --config-file my-config.yaml --no-input
 ```
 
+### Quick Generation with CLI Options
+
+For quick project generation without configuration files, use CLI options:
+
+```bash
+# Generate with custom project name
+egile-mcp-starter --project-name "weather_api_server" --no-input
+
+# Choose template and customize name
+egile-mcp-starter --template rag --project-name "document_search_server" --no-input
+
+# Generate in specific directory with custom name
+egile-mcp-starter --output-dir ./servers --project-name "my_custom_server" --verbose
+```
+
+### CLI Options Reference
+
+| Option | Description | Example |
+|--------|-------------|---------|
+| `--project-name` | Override project name (affects directory and package names) | `--project-name "my_server"` |
+| `--template` | Choose template (`mcp`, `rag`) | `--template rag` |
+| `--output-dir` | Output directory | `--output-dir ./projects` |
+| `--no-input` | Skip interactive prompts | `--no-input` |
+| `--verbose` | Show detailed output | `--verbose` |
+| `--list-templates` | List available templates | `--list-templates` |
+
+**Note:** The `--project-name` option is particularly useful for CI/CD pipelines where you need predictable directory names.
+
 ## Project Structure
 
 After generation, your project will have this structure:

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -33,7 +33,7 @@ egile-mcp-starter --template mcp
 The RAG template creates advanced MCP servers with vector search and document processing capabilities:
 
 **Features:**
-- Vector database integration (Chroma, Pinecone, Weaviate, Qdrant)
+- Vector database integration (Chroma, Pinecone, Weaviate, Qdrant, FAISS)
 - Multiple embedding models (Sentence Transformers, OpenAI, Cohere)
 - Document processing (PDF, DOCX, Excel, text files)
 - Web scraping capabilities
@@ -56,7 +56,7 @@ The RAG template creates advanced MCP servers with vector search and document pr
 
 | Option | Description | Choices |
 |--------|-------------|---------|
-| `vector_db` | Vector database to use | chroma, pinecone, weaviate, qdrant |
+| `vector_db` | Vector database to use | chroma, pinecone, weaviate, qdrant, faiss |
 | `embedding_model` | Embedding model provider | sentence-transformers, openai, cohere |
 | `document_loaders` | Include document loaders | y/n |
 | `web_scraping` | Include web scraping | y/n |

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -1,0 +1,277 @@
+# Templates and Plugin System
+
+The egile-mcp-starter uses a powerful plugin architecture that supports multiple project templates. This document provides detailed information about available templates and how to extend the system.
+
+## Available Templates
+
+### MCP Template (default)
+
+The standard MCP server template provides a solid foundation for building MCP servers:
+
+**Features:**
+- Standard MCP server with tools, resources, and prompts
+- Full FASTMCP framework integration  
+- Comprehensive testing suite with pytest
+- Development tools (Black, Flake8, MyPy, pre-commit)
+- Docker and docker-compose support
+- GitHub Actions CI/CD workflows
+- Multiple license options
+
+**Server Types:**
+- `tools`: Server with tool implementations for AI interactions
+- `resources`: Server with resource management for data access
+- `prompts`: Server with prompt templates for AI guidance  
+- `full`: Complete server with all capabilities
+
+**Usage:**
+```bash
+egile-mcp-starter --template mcp
+```
+
+### RAG Template
+
+The RAG template creates advanced MCP servers with vector search and document processing capabilities:
+
+**Features:**
+- Vector database integration (Chroma, Pinecone, Weaviate, Qdrant)
+- Multiple embedding models (Sentence Transformers, OpenAI, Cohere)
+- Document processing (PDF, DOCX, Excel, text files)
+- Web scraping capabilities
+- Configurable chunking strategies (recursive, semantic, fixed-size)
+- Optional reranking for improved relevance
+- Comprehensive configuration system
+
+**Generated MCP Tools:**
+- `ingest_documents`: Add documents to the vector database
+- `search_documents`: Semantic search with optional reranking
+- `get_document_chunks`: Retrieve specific document chunks
+- `scrape_and_index`: Web scraping and indexing (if enabled)
+
+**Generated MCP Resources:**
+- `documents://list`: List all indexed documents
+- `documents://metadata/{doc_id}`: Get document metadata
+- `chunks://search?q={query}`: Search document chunks
+
+**Configuration Options:**
+
+| Option | Description | Choices |
+|--------|-------------|---------|
+| `vector_db` | Vector database to use | chroma, pinecone, weaviate, qdrant |
+| `embedding_model` | Embedding model provider | sentence-transformers, openai, cohere |
+| `document_loaders` | Include document loaders | y/n |
+| `web_scraping` | Include web scraping | y/n |
+| `pdf_processing` | Include PDF processing | y/n |
+| `chunk_strategy` | Text chunking strategy | recursive, semantic, fixed |
+| `include_reranker` | Include reranking | y/n |
+
+**Usage:**
+```bash
+egile-mcp-starter --template rag
+```
+
+## Plugin Architecture
+
+### Core Components
+
+#### 1. TemplatePlugin Base Class
+
+All templates inherit from the `TemplatePlugin` abstract base class:
+
+```python
+from egile_mcp_starter.plugins.base import TemplatePlugin
+
+class MyTemplate(TemplatePlugin):
+    def get_template_path(self) -> Path:
+        """Return path to cookiecutter template directory"""
+        
+    def get_default_context(self) -> Dict[str, Any]:
+        """Return default template variables"""
+        
+    def get_supported_features(self) -> List[str]:
+        """Return list of supported features"""
+        
+    def validate_context(self, context: Dict[str, Any]) -> bool:
+        """Validate template context"""
+        
+    def pre_generate_hook(self, context: Dict[str, Any]) -> Dict[str, Any]:
+        """Called before project generation"""
+        
+    def post_generate_hook(self, project_path: Path, context: Dict[str, Any]) -> None:
+        """Called after project generation"""
+```
+
+#### 2. Template Registry
+
+The registry manages all available templates:
+
+```python
+from egile_mcp_starter import get_registry
+
+registry = get_registry()
+
+# List available templates
+templates = registry.list_plugins()
+
+# Get specific template
+template = registry.get_plugin("rag")
+
+# Register new template
+registry.register(MyTemplatePlugin())
+```
+
+### Creating Custom Templates
+
+#### Step 1: Create Template Plugin
+
+```python
+from pathlib import Path
+from typing import Any, Dict, List
+from egile_mcp_starter.plugins.base import TemplatePlugin
+
+class DatabaseTemplatePlugin(TemplatePlugin):
+    def __init__(self):
+        super().__init__(
+            name="database",
+            description="MCP server with database connectivity",
+            version="1.0.0"
+        )
+    
+    def get_template_path(self) -> Path:
+        return Path(__file__).parent / "database_template"
+    
+    def get_default_context(self) -> Dict[str, Any]:
+        return {
+            "project_name": "My Database MCP Server",
+            "database_type": "postgresql",
+            "include_migrations": "y",
+            "use_sqlalchemy": "y"
+        }
+    
+    def get_supported_features(self) -> List[str]:
+        return ["database", "migrations", "orm", "connection_pooling"]
+    
+    def validate_context(self, context: Dict[str, Any]) -> bool:
+        required = ["project_name", "database_type"]
+        return all(field in context for field in required)
+    
+    def pre_generate_hook(self, context: Dict[str, Any]) -> Dict[str, Any]:
+        # Add database-specific dependencies
+        db_type = context.get("database_type")
+        if db_type == "postgresql":
+            context["_db_driver"] = "psycopg2"
+        elif db_type == "mysql":
+            context["_db_driver"] = "pymysql"
+        return context
+    
+    def post_generate_hook(self, project_path: Path, context: Dict[str, Any]) -> None:
+        # Could initialize database schema, create config files, etc.
+        pass
+```
+
+#### Step 2: Create Cookiecutter Template
+
+Create the template directory structure:
+```
+database_template/
+├── cookiecutter.json
+└── {{cookiecutter.project_slug}}/
+    ├── src/
+    │   └── {{cookiecutter.project_slug}}/
+    │       ├── __init__.py
+    │       ├── server.py
+    │       └── database.py
+    ├── config.example.yaml
+    └── README.md
+```
+
+#### Step 3: Register Template
+
+For built-in templates, add to the registry:
+```python
+# In plugins/registry.py
+from .builtin.database_template import DatabaseTemplatePlugin
+self.register(DatabaseTemplatePlugin())
+```
+
+### External Plugins
+
+Third-party templates can be distributed as separate packages:
+
+#### Package Structure
+```
+my_mcp_templates/
+├── setup.py
+├── my_mcp_templates/
+│   ├── __init__.py
+│   └── api_template.py
+└── templates/
+    └── api/
+        └── cookiecutter.json
+```
+
+#### Entry Points Configuration
+```python
+# setup.py
+from setuptools import setup
+
+setup(
+    name="my-mcp-templates",
+    entry_points={
+        'egile_mcp_starter.templates': [
+            'api = my_mcp_templates.api_template:APITemplatePlugin',
+        ],
+    },
+)
+```
+
+#### Installation and Usage
+```bash
+# Install the external template package
+pip install my-mcp-templates
+
+# The template will be automatically discovered
+egile-mcp-starter --list-templates
+
+# Use the external template
+egile-mcp-starter --template api
+```
+
+## Template Development Best Practices
+
+### 1. Template Organization
+- Keep templates focused on specific use cases
+- Use clear, descriptive names and documentation
+- Include comprehensive examples and documentation
+
+### 2. Configuration Management
+- Provide sensible defaults
+- Use validation to catch configuration errors early
+- Support environment variable overrides
+
+### 3. Dependency Management
+- Compute dependencies dynamically based on features
+- Use optional dependencies for optional features
+- Pin versions for stability
+
+### 4. Testing
+- Include comprehensive test suites in generated projects
+- Test template generation with various configurations
+- Validate generated projects can be built and run
+
+### 5. Documentation
+- Provide clear README files in generated projects
+- Include configuration examples
+- Document all available tools and resources
+
+## Future Template Ideas
+
+Potential templates that could be added:
+
+- **API Gateway**: MCP server with REST API integration
+- **Database Connector**: Direct database query and manipulation tools
+- **File System**: File management and search capabilities
+- **Cloud Services**: Integration with AWS, GCP, Azure services
+- **Monitoring**: Observability and monitoring tools
+- **Authentication**: Auth-enabled MCP servers
+- **Workflow**: Process automation and workflow management
+- **Analytics**: Data analysis and visualization tools

--- a/egile_mcp_starter/__init__.py
+++ b/egile_mcp_starter/__init__.py
@@ -1,4 +1,4 @@
-"""Egile MCP Starter - A cookiecutter template for MCP servers using FASTMCP."""
+"""Egile MCP Starter - A cookiecutter template for MCP servers using FASTMCP with plugin support."""
 
 __version__ = "1.0.0"
 __author__ = "Jean-Baptiste Poullet"
@@ -6,5 +6,7 @@ __email__ = "jpoullet2000@gmail.com"
 
 from .cli import main
 from .generator import MCPProjectGenerator
+from .plugins.registry import get_registry
+from .plugins.base import TemplatePlugin
 
-__all__ = ["MCPProjectGenerator", "main"]
+__all__ = ["MCPProjectGenerator", "main", "get_registry", "TemplatePlugin"]

--- a/egile_mcp_starter/__init__.py
+++ b/egile_mcp_starter/__init__.py
@@ -1,4 +1,5 @@
-"""Egile MCP Starter - A cookiecutter template for MCP servers using FASTMCP with plugin support."""
+"""Egile MCP Starter - A cookiecutter template for MCP servers using FASTMCP
+with plugin support."""
 
 __version__ = "1.0.0"
 __author__ = "Jean-Baptiste Poullet"
@@ -6,7 +7,7 @@ __email__ = "jpoullet2000@gmail.com"
 
 from .cli import main
 from .generator import MCPProjectGenerator
-from .plugins.registry import get_registry
 from .plugins.base import TemplatePlugin
+from .plugins.registry import get_registry
 
 __all__ = ["MCPProjectGenerator", "main", "get_registry", "TemplatePlugin"]

--- a/egile_mcp_starter/cli.py
+++ b/egile_mcp_starter/cli.py
@@ -5,6 +5,7 @@ import sys
 import click
 
 from .generator import MCPProjectGenerator
+from .plugins.registry import get_registry
 
 
 @click.command()
@@ -27,12 +28,26 @@ from .generator import MCPProjectGenerator
     help="Use default values for all template variables",
 )
 @click.option("--verbose", "-v", is_flag=True, help="Print status to stdout")
+@click.option(
+    "--template",
+    "-t",
+    default="mcp",
+    help="Template to use for project generation",
+    type=click.Choice([]),  # Will be populated dynamically
+)
+@click.option(
+    "--list-templates",
+    is_flag=True,
+    help="List all available templates and exit",
+)
 def main(
     output_dir: str,
     no_input: bool,
     config_file: str,
     default_config: bool,
     verbose: bool,
+    template: str,
+    list_templates: bool,
 ) -> None:
     """
     Generate a new MCP server project using the FASTMCP framework.
@@ -43,7 +58,28 @@ def main(
     - Testing framework
     - Documentation
     - CI/CD configuration
+
+    Multiple templates are available:
+    - mcp: Standard MCP server template
+    - rag: RAG-enabled server with vector database support
     """
+    # Get the registry for template information
+    registry = get_registry()
+
+    # Handle list templates option
+    if list_templates:
+        click.echo("Available templates:")
+        for plugin in registry.list_plugins():
+            click.echo(f"  {plugin.name}: {plugin.description}")
+        return
+
+    # Validate template choice
+    if not registry.get_plugin(template):
+        available = ", ".join(registry.get_plugin_names())
+        click.echo(f"Error: Template '{template}' not found.", err=True)
+        click.echo(f"Available templates: {available}", err=True)
+        sys.exit(1)
+
     try:
         generator = MCPProjectGenerator(
             output_dir=output_dir,
@@ -51,32 +87,46 @@ def main(
             config_file=config_file,
             default_config=default_config,
             verbose=verbose,
+            template=template,
         )
 
         project_path = generator.generate()
 
-        if verbose:
-            click.echo(
-                f"✅ MCP server project generated successfully at: {project_path}"
-            )
-            click.echo("\n🚀 Next steps:")
-            click.echo(f"  cd {project_path}")
-            click.echo("  poetry install")
-            click.echo("  poetry run pytest")
-            click.echo("  poetry run python src/main.py")
-            click.echo("\n📚 Alternative commands:")
-            click.echo("  poetry shell  # Activate virtual environment")
-            click.echo("  poetry add <package>  # Add new dependencies")
-
-        sys.exit(0)
+        click.echo("✅ MCP server project generated successfully!")
+        click.echo(f"📁 Project location: {project_path}")
+        click.echo(f"🚀 Template used: {template}")
+        click.echo("")
+        click.echo("Next steps:")
+        project_name = (
+            project_path.name
+            if hasattr(project_path, "name")
+            else str(project_path).split("/")[-1]
+        )
+        click.echo(f"  cd {project_name}")
+        click.echo("  pip install -e .")
+        click.echo("  # Start developing your MCP server!")
 
     except Exception as e:
-        click.echo(f"❌ Error generating project: {e}", err=True)
-        if verbose:
-            import traceback
-
-            traceback.print_exc()
+        click.echo(f"❌ Error: {e}", err=True)
         sys.exit(1)
+
+
+# Dynamically populate template choices
+def _get_template_choices():
+    """Get available template choices for CLI."""
+    try:
+        registry = get_registry()
+        return registry.get_plugin_names()
+    except Exception:
+        return ["mcp"]  # Fallback to default
+
+
+# Update the template option with dynamic choices
+main.params[5].type = click.Choice(_get_template_choices())
+
+
+if __name__ == "__main__":
+    main()
 
 
 if __name__ == "__main__":

--- a/egile_mcp_starter/cli.py
+++ b/egile_mcp_starter/cli.py
@@ -28,6 +28,10 @@ from .plugins.registry import get_registry
     is_flag=True,
     help="Use default values for all template variables",
 )
+@click.option(
+    "--project-name",
+    help="Override the project name (affects directory name and package name)",
+)
 @click.option("--verbose", "-v", is_flag=True, help="Print status to stdout")
 @click.option(
     "--template",
@@ -46,6 +50,7 @@ def main(
     no_input: bool,
     config_file: str,
     default_config: bool,
+    project_name: str,
     verbose: bool,
     template: str,
     list_templates: bool,
@@ -89,6 +94,7 @@ def main(
             default_config=default_config,
             verbose=verbose,
             template=template,
+            project_name=project_name,
         )
 
         project_path = generator.generate()
@@ -123,7 +129,7 @@ def _get_template_choices() -> List[str]:
 
 
 # Update the template option with dynamic choices
-main.params[5].type = click.Choice(_get_template_choices())
+main.params[6].type = click.Choice(_get_template_choices())
 
 
 if __name__ == "__main__":

--- a/egile_mcp_starter/cli.py
+++ b/egile_mcp_starter/cli.py
@@ -127,8 +127,4 @@ main.params[5].type = click.Choice(_get_template_choices())
 
 
 if __name__ == "__main__":
-    main()
-
-
-if __name__ == "__main__":
     sys.exit(main())

--- a/egile_mcp_starter/cli.py
+++ b/egile_mcp_starter/cli.py
@@ -1,6 +1,7 @@
 """CLI interface for egile-mcp-starter."""
 
 import sys
+from typing import List
 
 import click
 
@@ -112,7 +113,7 @@ def main(
 
 
 # Dynamically populate template choices
-def _get_template_choices():
+def _get_template_choices() -> List[str]:
     """Get available template choices for CLI."""
     try:
         registry = get_registry()

--- a/egile_mcp_starter/generator.py
+++ b/egile_mcp_starter/generator.py
@@ -22,6 +22,7 @@ class MCPProjectGenerator:
         default_config: bool = False,
         verbose: bool = False,
         template: str = "mcp",
+        project_name: Optional[str] = None,
     ):
         """Initialize the MCP project generator.
 
@@ -32,12 +33,14 @@ class MCPProjectGenerator:
             default_config: Use default configuration values
             verbose: Enable verbose output
             template: Name of the template to use (default: "mcp")
+            project_name: Override the project name
         """
         self.output_dir = Path(output_dir).resolve()
         self.no_input = no_input or default_config
         self.config_file = config_file
         self.verbose = verbose
         self.template_name = template
+        self.project_name = project_name
 
         # Get the template registry
         self.registry = get_registry()
@@ -79,6 +82,12 @@ class MCPProjectGenerator:
         try:
             # Get default context from plugin
             default_context = plugin.get_default_context()
+
+            # Override project name if provided
+            if self.project_name:
+                default_context["project_name"] = self.project_name
+                if self.verbose:
+                    print(f"🏷️  Project name override: {self.project_name}")
 
             # Apply pre-generation hook
             if not self.no_input:

--- a/egile_mcp_starter/plugins/__init__.py
+++ b/egile_mcp_starter/plugins/__init__.py
@@ -1,0 +1,6 @@
+"""Plugin system for egile-mcp-starter templates."""
+
+from .base import TemplatePlugin
+from .registry import TemplateRegistry
+
+__all__ = ["TemplatePlugin", "TemplateRegistry"]

--- a/egile_mcp_starter/plugins/base.py
+++ b/egile_mcp_starter/plugins/base.py
@@ -1,0 +1,81 @@
+"""Base template plugin interface."""
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+class TemplatePlugin(ABC):
+    """Base class for template plugins."""
+
+    def __init__(self, name: str, description: str, version: str = "1.0.0"):
+        """Initialize the template plugin.
+
+        Args:
+            name: Unique name identifier for the template
+            description: Human-readable description of the template
+            version: Template version
+        """
+        self.name = name
+        self.description = description
+        self.version = version
+
+    @abstractmethod
+    def get_template_path(self) -> Path:
+        """Get the path to the cookiecutter template directory.
+
+        Returns:
+            Path to the template directory containing cookiecutter.json
+        """
+        pass
+
+    @abstractmethod
+    def get_default_context(self) -> Dict[str, Any]:
+        """Get default context variables for the template.
+
+        Returns:
+            Dictionary of default template variables
+        """
+        pass
+
+    def get_supported_features(self) -> List[str]:
+        """Get list of features supported by this template.
+
+        Returns:
+            List of feature names (e.g., ["docker", "github_actions", "rag"])
+        """
+        return []
+
+    def validate_context(self, context: Dict[str, Any]) -> bool:
+        """Validate the provided context for this template.
+
+        Args:
+            context: Template context variables
+
+        Returns:
+            True if context is valid, False otherwise
+        """
+        return True
+
+    def pre_generate_hook(self, context: Dict[str, Any]) -> Dict[str, Any]:
+        """Hook called before project generation.
+
+        Args:
+            context: Template context variables
+
+        Returns:
+            Modified context variables
+        """
+        return context
+
+    def post_generate_hook(self, project_path: Path, context: Dict[str, Any]) -> None:
+        """Hook called after project generation.
+
+        Args:
+            project_path: Path to the generated project
+            context: Template context variables used during generation
+        """
+        pass
+
+    def __repr__(self) -> str:
+        return f"TemplatePlugin(name='{self.name}', version='{self.version}')"

--- a/egile_mcp_starter/plugins/builtin/__init__.py
+++ b/egile_mcp_starter/plugins/builtin/__init__.py
@@ -1,0 +1,6 @@
+"""Built-in template plugins."""
+
+from .mcp_template import MCPTemplatePlugin
+from .rag_template import RAGTemplatePlugin
+
+__all__ = ["MCPTemplatePlugin", "RAGTemplatePlugin"]

--- a/egile_mcp_starter/plugins/builtin/mcp_template.py
+++ b/egile_mcp_starter/plugins/builtin/mcp_template.py
@@ -9,7 +9,7 @@ from ..base import TemplatePlugin
 class MCPTemplatePlugin(TemplatePlugin):
     """Original MCP server template plugin."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize the MCP template plugin."""
         super().__init__(
             name="mcp",

--- a/egile_mcp_starter/plugins/builtin/mcp_template.py
+++ b/egile_mcp_starter/plugins/builtin/mcp_template.py
@@ -87,8 +87,8 @@ class MCPTemplatePlugin(TemplatePlugin):
         Returns:
             Modified context variables
         """
-        # Ensure project_slug is properly formatted
-        if "project_name" in context and "project_slug" not in context:
+        # Ensure project_slug is properly formatted based on project_name
+        if "project_name" in context:
             project_slug = (
                 context["project_name"].lower().replace(" ", "_").replace("-", "_")
             )

--- a/egile_mcp_starter/plugins/builtin/mcp_template.py
+++ b/egile_mcp_starter/plugins/builtin/mcp_template.py
@@ -1,0 +1,110 @@
+"""MCP template plugin - the original/default template."""
+
+from pathlib import Path
+from typing import Any, Dict, List
+
+from ..base import TemplatePlugin
+
+
+class MCPTemplatePlugin(TemplatePlugin):
+    """Original MCP server template plugin."""
+
+    def __init__(self):
+        """Initialize the MCP template plugin."""
+        super().__init__(
+            name="mcp",
+            description="Standard MCP server template with FASTMCP framework",
+            version="1.0.0",
+        )
+
+    def get_template_path(self) -> Path:
+        """Get the path to the cookiecutter template directory.
+
+        Returns:
+            Path to the template directory containing cookiecutter.json
+        """
+        # Point to the existing template directory
+        return Path(__file__).parent.parent.parent / "template"
+
+    def get_default_context(self) -> Dict[str, Any]:
+        """Get default context variables for the template.
+
+        Returns:
+            Dictionary of default template variables
+        """
+        return {
+            "project_name": "My MCP Server",
+            "project_slug": "my_mcp_server",
+            "project_description": "A Model Context Protocol server built with FASTMCP",
+            "author_name": "Your Name",
+            "author_email": "your.email@example.com",
+            "github_username": "yourusername",
+            "version": "0.1.0",
+            "python_version": "3.11",
+            "use_docker": "y",
+            "use_github_actions": "y",
+            "use_pre_commit": "y",
+            "license": "MIT",
+            "include_examples": "y",
+            "server_type": "full",
+        }
+
+    def get_supported_features(self) -> List[str]:
+        """Get list of features supported by this template.
+
+        Returns:
+            List of feature names
+        """
+        return [
+            "docker",
+            "github_actions",
+            "pre_commit",
+            "testing",
+            "documentation",
+            "multiple_licenses",
+            "server_types",
+            "examples",
+        ]
+
+    def validate_context(self, context: Dict[str, Any]) -> bool:
+        """Validate the provided context for this template.
+
+        Args:
+            context: Template context variables
+
+        Returns:
+            True if context is valid, False otherwise
+        """
+        required_fields = ["project_name", "author_name", "author_email"]
+        return all(field in context and context[field] for field in required_fields)
+
+    def pre_generate_hook(self, context: Dict[str, Any]) -> Dict[str, Any]:
+        """Hook called before project generation.
+
+        Args:
+            context: Template context variables
+
+        Returns:
+            Modified context variables
+        """
+        # Ensure project_slug is properly formatted
+        if "project_name" in context and "project_slug" not in context:
+            project_slug = (
+                context["project_name"].lower().replace(" ", "_").replace("-", "_")
+            )
+            context["project_slug"] = project_slug
+
+        return context
+
+    def post_generate_hook(self, project_path: Path, context: Dict[str, Any]) -> None:
+        """Hook called after project generation.
+
+        Args:
+            project_path: Path to the generated project
+            context: Template context variables used during generation
+        """
+        # Could add post-generation steps like:
+        # - Initialize git repository
+        # - Set up virtual environment
+        # - Install pre-commit hooks
+        pass

--- a/egile_mcp_starter/plugins/builtin/rag_template.py
+++ b/egile_mcp_starter/plugins/builtin/rag_template.py
@@ -15,7 +15,7 @@ class RAGTemplatePlugin(TemplatePlugin):
         super().__init__(
             name="rag",
             description=(
-                "RAG-enabled MCP server with vector databases and " "retrieval tools"
+                "RAG-enabled MCP server with vector databases and retrieval tools"
             ),
             version="1.0.0",
         )

--- a/egile_mcp_starter/plugins/builtin/rag_template.py
+++ b/egile_mcp_starter/plugins/builtin/rag_template.py
@@ -10,7 +10,7 @@ class RAGTemplatePlugin(TemplatePlugin):
     """RAG MCP server template plugin with vector databases and retrieval
     capabilities."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize the RAG template plugin."""
         super().__init__(
             name="rag",

--- a/egile_mcp_starter/plugins/builtin/rag_template.py
+++ b/egile_mcp_starter/plugins/builtin/rag_template.py
@@ -119,8 +119,8 @@ class RAGTemplatePlugin(TemplatePlugin):
         Returns:
             Modified context variables
         """
-        # Ensure project_slug is properly formatted
-        if "project_name" in context and "project_slug" not in context:
+        # Ensure project_slug is properly formatted based on project_name
+        if "project_name" in context:
             project_slug = (
                 context["project_name"].lower().replace(" ", "_").replace("-", "_")
             )

--- a/egile_mcp_starter/plugins/builtin/rag_template.py
+++ b/egile_mcp_starter/plugins/builtin/rag_template.py
@@ -1,0 +1,173 @@
+"""RAG (Retrieval-Augmented Generation) template plugin."""
+
+from pathlib import Path
+from typing import Any, Dict, List
+
+from ..base import TemplatePlugin
+
+
+class RAGTemplatePlugin(TemplatePlugin):
+    """RAG MCP server template plugin with vector databases and retrieval capabilities."""
+
+    def __init__(self):
+        """Initialize the RAG template plugin."""
+        super().__init__(
+            name="rag",
+            description="RAG-enabled MCP server with vector databases and retrieval tools",
+            version="1.0.0",
+        )
+
+    def get_template_path(self) -> Path:
+        """Get the path to the cookiecutter template directory.
+
+        Returns:
+            Path to the template directory containing cookiecutter.json
+        """
+        return Path(__file__).parent.parent.parent / "templates" / "rag"
+
+    def get_default_context(self) -> Dict[str, Any]:
+        """Get default context variables for the template.
+
+        Returns:
+            Dictionary of default template variables
+        """
+        return {
+            "project_name": "My RAG MCP Server",
+            "project_slug": "my_rag_mcp_server",
+            "project_description": "A RAG-enabled Model Context Protocol server with vector search capabilities",
+            "author_name": "Your Name",
+            "author_email": "your.email@example.com",
+            "github_username": "yourusername",
+            "version": "0.1.0",
+            "python_version": "3.11",
+            "use_docker": "y",
+            "use_github_actions": "y",
+            "use_pre_commit": "y",
+            "license": "MIT",
+            "include_examples": "y",
+            "vector_db": "chroma",  # chroma, pinecone, weaviate, qdrant
+            "embedding_model": "sentence-transformers",  # sentence-transformers, openai, cohere
+            "document_loaders": "y",  # Include various document loaders
+            "web_scraping": "y",  # Include web scraping capabilities
+            "pdf_processing": "y",  # Include PDF processing
+            "chunk_strategy": "recursive",  # recursive, semantic, fixed
+            "include_reranker": "y",  # Include reranking capabilities
+        }
+
+    def get_supported_features(self) -> List[str]:
+        """Get list of features supported by this template.
+
+        Returns:
+            List of feature names
+        """
+        return [
+            "docker",
+            "github_actions",
+            "pre_commit",
+            "testing",
+            "documentation",
+            "multiple_licenses",
+            "vector_databases",
+            "embedding_models",
+            "document_loaders",
+            "web_scraping",
+            "pdf_processing",
+            "text_chunking",
+            "semantic_search",
+            "reranking",
+            "examples",
+        ]
+
+    def validate_context(self, context: Dict[str, Any]) -> bool:
+        """Validate the provided context for this template.
+
+        Args:
+            context: Template context variables
+
+        Returns:
+            True if context is valid, False otherwise
+        """
+        required_fields = ["project_name", "author_name", "author_email"]
+        if not all(field in context and context[field] for field in required_fields):
+            return False
+
+        # Validate vector database choice
+        valid_vector_dbs = ["chroma", "pinecone", "weaviate", "qdrant"]
+        if context.get("vector_db") not in valid_vector_dbs:
+            return False
+
+        # Validate embedding model choice
+        valid_embedding_models = ["sentence-transformers", "openai", "cohere"]
+        if context.get("embedding_model") not in valid_embedding_models:
+            return False
+
+        return True
+
+    def pre_generate_hook(self, context: Dict[str, Any]) -> Dict[str, Any]:
+        """Hook called before project generation.
+
+        Args:
+            context: Template context variables
+
+        Returns:
+            Modified context variables
+        """
+        # Ensure project_slug is properly formatted
+        if "project_name" in context and "project_slug" not in context:
+            project_slug = (
+                context["project_name"].lower().replace(" ", "_").replace("-", "_")
+            )
+            context["project_slug"] = project_slug
+
+        # Set up dependencies based on choices
+        dependencies = ["fastmcp", "pydantic", "pyyaml", "click"]
+
+        # Add vector database dependencies
+        vector_db = context.get("vector_db", "chroma")
+        if vector_db == "chroma":
+            dependencies.extend(["chromadb", "sqlite3"])
+        elif vector_db == "pinecone":
+            dependencies.append("pinecone-client")
+        elif vector_db == "weaviate":
+            dependencies.append("weaviate-client")
+        elif vector_db == "qdrant":
+            dependencies.append("qdrant-client")
+
+        # Add embedding model dependencies
+        embedding_model = context.get("embedding_model", "sentence-transformers")
+        if embedding_model == "sentence-transformers":
+            dependencies.append("sentence-transformers")
+        elif embedding_model == "openai":
+            dependencies.append("openai")
+        elif embedding_model == "cohere":
+            dependencies.append("cohere")
+
+        # Add document processing dependencies
+        if context.get("pdf_processing") == "y":
+            dependencies.extend(["pypdf2", "pdfplumber"])
+
+        if context.get("web_scraping") == "y":
+            dependencies.extend(["requests", "beautifulsoup4", "scrapy"])
+
+        if context.get("document_loaders") == "y":
+            dependencies.extend(["python-docx", "openpyxl"])
+
+        if context.get("include_reranker") == "y":
+            dependencies.append("sentence-transformers")  # for cross-encoder models
+
+        context["_computed_dependencies"] = dependencies
+
+        return context
+
+    def post_generate_hook(self, project_path: Path, context: Dict[str, Any]) -> None:
+        """Hook called after project generation.
+
+        Args:
+            project_path: Path to the generated project
+            context: Template context variables used during generation
+        """
+        # Could add RAG-specific post-generation steps like:
+        # - Download default embedding models
+        # - Initialize vector database
+        # - Create sample documents for testing
+        pass

--- a/egile_mcp_starter/plugins/builtin/rag_template.py
+++ b/egile_mcp_starter/plugins/builtin/rag_template.py
@@ -45,7 +45,7 @@ class RAGTemplatePlugin(TemplatePlugin):
             "use_pre_commit": "y",
             "license": "MIT",
             "include_examples": "y",
-            "vector_db": "chroma",  # chroma, pinecone, weaviate, qdrant
+            "vector_db": "chroma",  # chroma, pinecone, weaviate, qdrant, faiss
             "embedding_model": "sentence-transformers",  # sentence-transformers, openai, cohere
             "document_loaders": "y",  # Include various document loaders
             "web_scraping": "y",  # Include web scraping capabilities
@@ -92,7 +92,7 @@ class RAGTemplatePlugin(TemplatePlugin):
             return False
 
         # Validate vector database choice
-        valid_vector_dbs = ["chroma", "pinecone", "weaviate", "qdrant"]
+        valid_vector_dbs = ["chroma", "pinecone", "weaviate", "qdrant", "faiss"]
         if context.get("vector_db") not in valid_vector_dbs:
             return False
 
@@ -132,6 +132,8 @@ class RAGTemplatePlugin(TemplatePlugin):
             dependencies.append("weaviate-client")
         elif vector_db == "qdrant":
             dependencies.append("qdrant-client")
+        elif vector_db == "faiss":
+            dependencies.extend(["faiss-cpu", "numpy"])
 
         # Add embedding model dependencies
         embedding_model = context.get("embedding_model", "sentence-transformers")

--- a/egile_mcp_starter/plugins/builtin/rag_template.py
+++ b/egile_mcp_starter/plugins/builtin/rag_template.py
@@ -7,13 +7,16 @@ from ..base import TemplatePlugin
 
 
 class RAGTemplatePlugin(TemplatePlugin):
-    """RAG MCP server template plugin with vector databases and retrieval capabilities."""
+    """RAG MCP server template plugin with vector databases and retrieval
+    capabilities."""
 
     def __init__(self):
         """Initialize the RAG template plugin."""
         super().__init__(
             name="rag",
-            description="RAG-enabled MCP server with vector databases and retrieval tools",
+            description=(
+                "RAG-enabled MCP server with vector databases and " "retrieval tools"
+            ),
             version="1.0.0",
         )
 
@@ -34,7 +37,10 @@ class RAGTemplatePlugin(TemplatePlugin):
         return {
             "project_name": "My RAG MCP Server",
             "project_slug": "my_rag_mcp_server",
-            "project_description": "A RAG-enabled Model Context Protocol server with vector search capabilities",
+            "project_description": (
+                "A RAG-enabled Model Context Protocol server "
+                "with vector search capabilities"
+            ),
             "author_name": "Your Name",
             "author_email": "your.email@example.com",
             "github_username": "yourusername",
@@ -46,7 +52,8 @@ class RAGTemplatePlugin(TemplatePlugin):
             "license": "MIT",
             "include_examples": "y",
             "vector_db": "chroma",  # chroma, pinecone, weaviate, qdrant, faiss
-            "embedding_model": "sentence-transformers",  # sentence-transformers, openai, cohere
+            # sentence-transformers, openai, cohere
+            "embedding_model": "sentence-transformers",
             "document_loaders": "y",  # Include various document loaders
             "web_scraping": "y",  # Include web scraping capabilities
             "pdf_processing": "y",  # Include PDF processing
@@ -122,44 +129,57 @@ class RAGTemplatePlugin(TemplatePlugin):
         # Set up dependencies based on choices
         dependencies = ["fastmcp", "pydantic", "pyyaml", "click"]
 
-        # Add vector database dependencies
-        vector_db = context.get("vector_db", "chroma")
-        if vector_db == "chroma":
-            dependencies.extend(["chromadb", "sqlite3"])
-        elif vector_db == "pinecone":
-            dependencies.append("pinecone-client")
-        elif vector_db == "weaviate":
-            dependencies.append("weaviate-client")
-        elif vector_db == "qdrant":
-            dependencies.append("qdrant-client")
-        elif vector_db == "faiss":
-            dependencies.extend(["faiss-cpu", "numpy"])
-
-        # Add embedding model dependencies
-        embedding_model = context.get("embedding_model", "sentence-transformers")
-        if embedding_model == "sentence-transformers":
-            dependencies.append("sentence-transformers")
-        elif embedding_model == "openai":
-            dependencies.append("openai")
-        elif embedding_model == "cohere":
-            dependencies.append("cohere")
-
-        # Add document processing dependencies
-        if context.get("pdf_processing") == "y":
-            dependencies.extend(["pypdf2", "pdfplumber"])
-
-        if context.get("web_scraping") == "y":
-            dependencies.extend(["requests", "beautifulsoup4", "scrapy"])
-
-        if context.get("document_loaders") == "y":
-            dependencies.extend(["python-docx", "openpyxl"])
-
-        if context.get("include_reranker") == "y":
-            dependencies.append("sentence-transformers")  # for cross-encoder models
+        # Add specific dependencies
+        dependencies.extend(self._get_vector_db_dependencies(context))
+        dependencies.extend(self._get_embedding_dependencies(context))
+        dependencies.extend(self._get_document_processing_dependencies(context))
 
         context["_computed_dependencies"] = dependencies
-
         return context
+
+    def _get_vector_db_dependencies(self, context: Dict[str, Any]) -> list:
+        """Get dependencies for the selected vector database."""
+        vector_db = context.get("vector_db", "chroma")
+        if vector_db == "chroma":
+            return ["chromadb", "sqlite3"]
+        elif vector_db == "pinecone":
+            return ["pinecone-client"]
+        elif vector_db == "weaviate":
+            return ["weaviate-client"]
+        elif vector_db == "qdrant":
+            return ["qdrant-client"]
+        elif vector_db == "faiss":
+            return ["faiss-cpu", "numpy"]
+        return []
+
+    def _get_embedding_dependencies(self, context: Dict[str, Any]) -> list:
+        """Get dependencies for the selected embedding model."""
+        embedding_model = context.get("embedding_model", "sentence-transformers")
+        if embedding_model == "sentence-transformers":
+            return ["sentence-transformers"]
+        elif embedding_model == "openai":
+            return ["openai"]
+        elif embedding_model == "cohere":
+            return ["cohere"]
+        return []
+
+    def _get_document_processing_dependencies(self, context: Dict[str, Any]) -> list:
+        """Get dependencies for document processing features."""
+        deps = []
+
+        if context.get("pdf_processing") == "y":
+            deps.extend(["pypdf2", "pdfplumber"])
+
+        if context.get("web_scraping") == "y":
+            deps.extend(["requests", "beautifulsoup4", "scrapy"])
+
+        if context.get("document_loaders") == "y":
+            deps.extend(["python-docx", "openpyxl"])
+
+        if context.get("include_reranker") == "y":
+            deps.append("sentence-transformers")  # for cross-encoder models
+
+        return deps
 
     def post_generate_hook(self, project_path: Path, context: Dict[str, Any]) -> None:
         """Hook called after project generation.

--- a/egile_mcp_starter/plugins/registry.py
+++ b/egile_mcp_starter/plugins/registry.py
@@ -1,0 +1,148 @@
+"""Template registry for managing template plugins."""
+
+import importlib.util
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from .base import TemplatePlugin
+
+
+class TemplateRegistry:
+    """Registry for managing template plugins."""
+
+    def __init__(self):
+        """Initialize the template registry."""
+        self._plugins: Dict[str, TemplatePlugin] = {}
+        self._discover_builtin_templates()
+
+    def register(self, plugin: TemplatePlugin) -> None:
+        """Register a template plugin.
+
+        Args:
+            plugin: Template plugin to register
+
+        Raises:
+            ValueError: If a plugin with the same name is already registered
+        """
+        if plugin.name in self._plugins:
+            raise ValueError(f"Template plugin '{plugin.name}' is already registered")
+
+        self._plugins[plugin.name] = plugin
+
+    def unregister(self, name: str) -> None:
+        """Unregister a template plugin.
+
+        Args:
+            name: Name of the plugin to unregister
+        """
+        self._plugins.pop(name, None)
+
+    def get_plugin(self, name: str) -> Optional[TemplatePlugin]:
+        """Get a template plugin by name.
+
+        Args:
+            name: Name of the template plugin
+
+        Returns:
+            Template plugin or None if not found
+        """
+        return self._plugins.get(name)
+
+    def list_plugins(self) -> List[TemplatePlugin]:
+        """List all registered template plugins.
+
+        Returns:
+            List of registered template plugins
+        """
+        return list(self._plugins.values())
+
+    def get_plugin_names(self) -> List[str]:
+        """Get names of all registered template plugins.
+
+        Returns:
+            List of plugin names
+        """
+        return list(self._plugins.keys())
+
+    def _discover_builtin_templates(self) -> None:
+        """Discover and register built-in template plugins."""
+        # Register the default MCP template
+        from .builtin.mcp_template import MCPTemplatePlugin
+
+        self.register(MCPTemplatePlugin())
+
+        # Register the RAG template
+        from .builtin.rag_template import RAGTemplatePlugin
+
+        self.register(RAGTemplatePlugin())
+
+        # Try to discover additional built-in templates
+        builtin_dir = Path(__file__).parent / "builtin"
+        if builtin_dir.exists():
+            for plugin_file in builtin_dir.glob("*_template.py"):
+                if plugin_file.name in ["mcp_template.py", "rag_template.py"]:
+                    continue  # Already registered above
+
+                try:
+                    self._load_builtin_plugin(plugin_file)
+                except Exception:
+                    # Silently skip plugins that fail to load
+                    pass
+
+    def _load_builtin_plugin(self, plugin_file: Path) -> None:
+        """Load a built-in plugin from a file.
+
+        Args:
+            plugin_file: Path to the plugin file
+        """
+        module_name = plugin_file.stem
+        spec = importlib.util.spec_from_file_location(module_name, plugin_file)
+
+        if spec and spec.loader:
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+
+            # Look for plugin classes
+            for attr_name in dir(module):
+                attr = getattr(module, attr_name)
+                if (
+                    isinstance(attr, type)
+                    and issubclass(attr, TemplatePlugin)
+                    and attr != TemplatePlugin
+                ):
+                    try:
+                        plugin_instance = attr()
+                        self.register(plugin_instance)
+                    except Exception:
+                        pass  # Skip plugins that fail to instantiate
+
+    def discover_external_plugins(self) -> None:
+        """Discover external template plugins via entry points."""
+        try:
+            import pkg_resources
+
+            for entry_point in pkg_resources.iter_entry_points(
+                "egile_mcp_starter.templates"
+            ):
+                try:
+                    plugin_class = entry_point.load()
+                    plugin_instance = plugin_class()
+                    self.register(plugin_instance)
+                except Exception:
+                    pass  # Skip plugins that fail to load
+        except ImportError:
+            # pkg_resources not available
+            pass
+
+
+# Global registry instance
+_registry = TemplateRegistry()
+
+
+def get_registry() -> TemplateRegistry:
+    """Get the global template registry instance.
+
+    Returns:
+        Global template registry
+    """
+    return _registry

--- a/egile_mcp_starter/plugins/registry.py
+++ b/egile_mcp_starter/plugins/registry.py
@@ -119,11 +119,14 @@ class TemplateRegistry:
     def discover_external_plugins(self) -> None:
         """Discover external template plugins via entry points."""
         try:
-            import pkg_resources
+            try:
+                # Python 3.8+
+                from importlib.metadata import entry_points
+            except ImportError:
+                # Python < 3.8
+                from importlib_metadata import entry_points  # type: ignore
 
-            for entry_point in pkg_resources.iter_entry_points(
-                "egile_mcp_starter.templates"
-            ):
+            for entry_point in entry_points(group="egile_mcp_starter.templates"):
                 try:
                     plugin_class = entry_point.load()
                     plugin_instance = plugin_class()

--- a/egile_mcp_starter/plugins/registry.py
+++ b/egile_mcp_starter/plugins/registry.py
@@ -10,7 +10,7 @@ from .base import TemplatePlugin
 class TemplateRegistry:
     """Registry for managing template plugins."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize the template registry."""
         self._plugins: Dict[str, TemplatePlugin] = {}
         self._discover_builtin_templates()
@@ -111,7 +111,7 @@ class TemplateRegistry:
                     and attr != TemplatePlugin
                 ):
                     try:
-                        plugin_instance = attr()
+                        plugin_instance = attr()  # type: ignore[call-arg]
                         self.register(plugin_instance)
                     except Exception:
                         pass  # Skip plugins that fail to instantiate

--- a/egile_mcp_starter/templates/rag/cookiecutter.json
+++ b/egile_mcp_starter/templates/rag/cookiecutter.json
@@ -12,7 +12,7 @@
     "use_pre_commit": ["y", "n"],
     "license": ["MIT", "Apache-2.0", "GPL-3.0", "BSD-3-Clause", "None"],
     "include_examples": ["y", "n"],
-    "vector_db": ["chroma", "pinecone", "weaviate", "qdrant"],
+    "vector_db": ["chroma", "pinecone", "weaviate", "qdrant", "faiss"],
     "embedding_model": ["sentence-transformers", "openai", "cohere"],
     "document_loaders": ["y", "n"],
     "web_scraping": ["y", "n"],

--- a/egile_mcp_starter/templates/rag/cookiecutter.json
+++ b/egile_mcp_starter/templates/rag/cookiecutter.json
@@ -1,0 +1,29 @@
+{
+    "project_name": "My RAG MCP Server",
+    "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}",
+    "project_description": "A RAG-enabled Model Context Protocol server with vector search capabilities",
+    "author_name": "Your Name",
+    "author_email": "your.email@example.com",
+    "github_username": "yourusername",
+    "version": "0.1.0",
+    "python_version": ["3.11", "3.10", "3.12"],
+    "use_docker": ["y", "n"],
+    "use_github_actions": ["y", "n"],
+    "use_pre_commit": ["y", "n"],
+    "license": ["MIT", "Apache-2.0", "GPL-3.0", "BSD-3-Clause", "None"],
+    "include_examples": ["y", "n"],
+    "vector_db": ["chroma", "pinecone", "weaviate", "qdrant"],
+    "embedding_model": ["sentence-transformers", "openai", "cohere"],
+    "document_loaders": ["y", "n"],
+    "web_scraping": ["y", "n"],
+    "pdf_processing": ["y", "n"],
+    "chunk_strategy": ["recursive", "semantic", "fixed"],
+    "include_reranker": ["y", "n"],
+    "_copy_without_render": [
+        "*.pyc",
+        "__pycache__",
+        ".git",
+        ".DS_Store",
+        ".github/workflows/ci.yml"
+    ]
+}

--- a/egile_mcp_starter/templates/rag/{{cookiecutter.project_slug}}/README.md
+++ b/egile_mcp_starter/templates/rag/{{cookiecutter.project_slug}}/README.md
@@ -1,0 +1,120 @@
+# {{ cookiecutter.project_name }}
+
+{{ cookiecutter.project_description }}
+
+## Features
+
+- 🔍 **Vector Search**: Powered by {{ cookiecutter.vector_db }}
+- 🤖 **Embeddings**: Using {{ cookiecutter.embedding_model }}
+- 📚 **Document Processing**: {% if cookiecutter.pdf_processing == 'y' %}PDF, {% endif %}{% if cookiecutter.document_loaders == 'y' %}DOCX, Excel, {% endif %}Text files
+- 🌐 **Web Scraping**: {% if cookiecutter.web_scraping == 'y' %}Enabled{% else %}Disabled{% endif %}
+- 🧠 **Chunking Strategy**: {{ cookiecutter.chunk_strategy }}
+- 🔄 **Reranking**: {% if cookiecutter.include_reranker == 'y' %}Enabled{% else %}Disabled{% endif %}
+
+## Installation
+
+```bash
+pip install -e .
+```
+
+## Configuration
+
+Copy `config.example.yaml` to `config.yaml` and configure:
+
+```yaml
+vector_db:
+  type: {{ cookiecutter.vector_db }}
+  {% if cookiecutter.vector_db == 'chroma' %}
+  path: "./data/chroma"
+  {% elif cookiecutter.vector_db == 'pinecone' %}
+  api_key: "your-pinecone-api-key"
+  environment: "your-pinecone-environment"
+  index_name: "your-index-name"
+  {% elif cookiecutter.vector_db == 'weaviate' %}
+  url: "http://localhost:8080"
+  {% elif cookiecutter.vector_db == 'qdrant' %}
+  url: "http://localhost:6333"
+  {% endif %}
+
+embedding:
+  model: {{ cookiecutter.embedding_model }}
+  {% if cookiecutter.embedding_model == 'openai' %}
+  api_key: "your-openai-api-key"
+  {% elif cookiecutter.embedding_model == 'cohere' %}
+  api_key: "your-cohere-api-key"
+  {% endif %}
+
+chunking:
+  strategy: {{ cookiecutter.chunk_strategy }}
+  chunk_size: 1000
+  chunk_overlap: 200
+
+{% if cookiecutter.include_reranker == 'y' %}
+reranker:
+  model: "cross-encoder/ms-marco-MiniLM-L-6-v2"
+  top_k: 10
+{% endif %}
+```
+
+## Usage
+
+### As MCP Server
+
+Configure in your MCP client:
+
+```json
+{
+  "mcpServers": {
+    "{{ cookiecutter.project_slug }}": {
+      "command": "python",
+      "args": ["/path/to/{{ cookiecutter.project_slug }}/src/main.py"],
+      "env": {
+        "LOG_LEVEL": "INFO",
+        "CONFIG_PATH": "/path/to/config.yaml"
+      }
+    }
+  }
+}
+```
+
+### Available Tools
+
+- `ingest_documents`: Add documents to the vector database
+- `search_documents`: Semantic search across indexed documents
+- `get_document_chunks`: Retrieve specific document chunks
+{% if cookiecutter.web_scraping == 'y' %}
+- `scrape_and_index`: Scrape web pages and add to index
+{% endif %}
+{% if cookiecutter.include_reranker == 'y' %}
+- `rerank_results`: Rerank search results for better relevance
+{% endif %}
+
+### Available Resources
+
+- `documents://list`: List all indexed documents
+- `documents://metadata/{doc_id}`: Get document metadata
+- `chunks://search?q={query}`: Search document chunks
+
+## Development
+
+```bash
+# Install development dependencies
+pip install -e ".[dev]"
+
+# Run tests
+pytest
+
+# Format code
+black .
+
+# Type checking
+mypy src/
+```
+
+## License
+
+This project is licensed under the {{ cookiecutter.license }} License.
+
+---
+
+Built with ❤️ using [FASTMCP](https://github.com/jlowin/fastmcp) and the [Model Context Protocol](https://modelcontextprotocol.io/)

--- a/egile_mcp_starter/templates/rag/{{cookiecutter.project_slug}}/README.md
+++ b/egile_mcp_starter/templates/rag/{{cookiecutter.project_slug}}/README.md
@@ -26,6 +26,9 @@ vector_db:
   type: {{ cookiecutter.vector_db }}
   {% if cookiecutter.vector_db == 'chroma' %}
   path: "./data/chroma"
+  {% elif cookiecutter.vector_db == 'faiss' %}
+  database_url: "./data/faiss"
+  dimension: 384
   {% elif cookiecutter.vector_db == 'pinecone' %}
   api_key: "your-pinecone-api-key"
   environment: "your-pinecone-environment"

--- a/egile_mcp_starter/templates/rag/{{cookiecutter.project_slug}}/config.example.yaml
+++ b/egile_mcp_starter/templates/rag/{{cookiecutter.project_slug}}/config.example.yaml
@@ -1,0 +1,111 @@
+# Configuration for {{ cookiecutter.project_name }}
+# Copy this file to config.yaml and customize as needed
+
+# Server configuration
+server:
+  host: "localhost"
+  port: 8000
+  log_level: "INFO"
+
+# Vector database configuration
+vector_db:
+  type: "{{ cookiecutter.vector_db }}"
+  {% if cookiecutter.vector_db == "chroma" %}
+  # Chroma configuration
+  path: "./data/chroma"
+  collection_name: "documents"
+  {% elif cookiecutter.vector_db == "pinecone" %}
+  # Pinecone configuration
+  api_key: "${PINECONE_API_KEY}"
+  environment: "${PINECONE_ENVIRONMENT}"
+  index_name: "rag-documents"
+  {% elif cookiecutter.vector_db == "weaviate" %}
+  # Weaviate configuration
+  url: "http://localhost:8080"
+  class_name: "Document"
+  {% elif cookiecutter.vector_db == "qdrant" %}
+  # Qdrant configuration
+  url: "http://localhost:6333"
+  collection_name: "documents"
+  {% endif %}
+
+# Embedding model configuration
+embedding:
+  model: "{{ cookiecutter.embedding_model }}"
+  {% if cookiecutter.embedding_model == "sentence-transformers" %}
+  # Sentence Transformers configuration
+  model_name: "all-MiniLM-L6-v2"
+  device: "cpu"  # or "cuda" if available
+  {% elif cookiecutter.embedding_model == "openai" %}
+  # OpenAI configuration
+  api_key: "${OPENAI_API_KEY}"
+  model_name: "text-embedding-ada-002"
+  {% elif cookiecutter.embedding_model == "cohere" %}
+  # Cohere configuration
+  api_key: "${COHERE_API_KEY}"
+  model_name: "embed-english-v3.0"
+  {% endif %}
+
+# Text chunking configuration
+chunking:
+  strategy: "{{ cookiecutter.chunk_strategy }}"
+  chunk_size: 1000
+  chunk_overlap: 200
+  {% if cookiecutter.chunk_strategy == "semantic" %}
+  # Semantic chunking options
+  similarity_threshold: 0.5
+  {% elif cookiecutter.chunk_strategy == "fixed" %}
+  # Fixed size chunking options
+  separators: ["\n\n", "\n", ". ", " "]
+  {% endif %}
+
+{% if cookiecutter.include_reranker == "y" %}
+# Reranking configuration
+reranker:
+  enabled: true
+  model: "cross-encoder/ms-marco-MiniLM-L-6-v2"
+  top_k: 10
+  score_threshold: 0.3
+{% endif %}
+
+{% if cookiecutter.web_scraping == "y" %}
+# Web scraping configuration
+web_scraping:
+  user_agent: "{{ cookiecutter.project_slug }}/{{ cookiecutter.version }}"
+  max_pages: 100
+  delay: 1.0  # seconds between requests
+  timeout: 30
+{% endif %}
+
+{% if cookiecutter.pdf_processing == "y" %}
+# PDF processing configuration
+pdf_processing:
+  extract_images: false
+  preserve_layout: true
+  password: null
+{% endif %}
+
+# Document processing configuration
+document_processing:
+  max_file_size: 10485760  # 10MB in bytes
+  allowed_extensions: [
+    ".txt", ".md", ".rst",
+    {% if cookiecutter.pdf_processing == "y" %}".pdf",{% endif %}
+    {% if cookiecutter.document_loaders == "y" %}".docx", ".xlsx", ".pptx",{% endif %}
+  ]
+  ignore_patterns: ["*.tmp", "*.log", "__pycache__/*"]
+
+# Search configuration
+search:
+  default_limit: 10
+  max_limit: 100
+  similarity_threshold: 0.7
+  {% if cookiecutter.include_reranker == "y" %}
+  use_reranking: true
+  {% endif %}
+
+# Caching configuration (optional)
+cache:
+  enabled: true
+  ttl: 3600  # 1 hour in seconds
+  max_size: 1000  # maximum number of cached items

--- a/egile_mcp_starter/templates/rag/{{cookiecutter.project_slug}}/config.example.yaml
+++ b/egile_mcp_starter/templates/rag/{{cookiecutter.project_slug}}/config.example.yaml
@@ -14,11 +14,16 @@ vector_db:
   # Chroma configuration
   path: "./data/chroma"
   collection_name: "documents"
+  {% elif cookiecutter.vector_db == "faiss" %}
+  # FAISS configuration
+  database_url: "./data/faiss"
+  dimension: 384  # Match your embedding model dimension
   {% elif cookiecutter.vector_db == "pinecone" %}
   # Pinecone configuration
   api_key: "${PINECONE_API_KEY}"
   environment: "${PINECONE_ENVIRONMENT}"
   index_name: "rag-documents"
+  dimension: 384
   {% elif cookiecutter.vector_db == "weaviate" %}
   # Weaviate configuration
   url: "http://localhost:8080"

--- a/egile_mcp_starter/templates/rag/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/egile_mcp_starter/templates/rag/{{cookiecutter.project_slug}}/pyproject.toml
@@ -1,0 +1,115 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "{{ cookiecutter.project_slug }}"
+version = "{{ cookiecutter.version }}"
+description = "{{ cookiecutter.project_description }}"
+authors = [{name = "{{ cookiecutter.author_name }}", email = "{{ cookiecutter.author_email }}"}]
+readme = "README.md"
+requires-python = ">={{ cookiecutter.python_version }}"
+keywords = ["mcp", "model-context-protocol", "fastmcp", "rag", "vector-search", "ai"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    {% if cookiecutter.license == "MIT" %}
+    "License :: OSI Approved :: MIT License",
+    {% elif cookiecutter.license == "Apache-2.0" %}
+    "License :: OSI Approved :: Apache Software License",
+    {% elif cookiecutter.license == "GPL-3.0" %}
+    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+    {% elif cookiecutter.license == "BSD-3-Clause" %}
+    "License :: OSI Approved :: BSD License",
+    {% endif %}
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: {{ cookiecutter.python_version }}",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
+dependencies = [
+    "fastmcp>=0.1.0",
+    "pydantic>=2.0.0",
+    "pyyaml>=6.0",
+    "click>=8.0.0",
+    {% if cookiecutter.vector_db == "chroma" %}
+    "chromadb>=0.4.0",
+    {% elif cookiecutter.vector_db == "pinecone" %}
+    "pinecone-client>=3.0.0",
+    {% elif cookiecutter.vector_db == "weaviate" %}
+    "weaviate-client>=4.0.0",
+    {% elif cookiecutter.vector_db == "qdrant" %}
+    "qdrant-client>=1.6.0",
+    {% endif %}
+    {% if cookiecutter.embedding_model == "sentence-transformers" %}
+    "sentence-transformers>=2.2.0",
+    "torch>=2.0.0",
+    {% elif cookiecutter.embedding_model == "openai" %}
+    "openai>=1.0.0",
+    {% elif cookiecutter.embedding_model == "cohere" %}
+    "cohere>=4.0.0",
+    {% endif %}
+    {% if cookiecutter.pdf_processing == "y" %}
+    "pypdf2>=3.0.0",
+    "pdfplumber>=0.9.0",
+    {% endif %}
+    {% if cookiecutter.web_scraping == "y" %}
+    "requests>=2.31.0",
+    "beautifulsoup4>=4.12.0",
+    "scrapy>=2.11.0",
+    {% endif %}
+    {% if cookiecutter.document_loaders == "y" %}
+    "python-docx>=0.8.11",
+    "openpyxl>=3.1.0",
+    {% endif %}
+    {% if cookiecutter.include_reranker == "y" %}
+    "rank-bm25>=0.2.2",
+    {% endif %}
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0.0",
+    "pytest-cov>=4.0.0",
+    "pytest-asyncio>=0.21.0",
+    "black>=23.0.0",
+    "flake8>=6.0.0",
+    "mypy>=1.0.0",
+    "pre-commit>=3.0.0",
+    "isort>=5.12.0",
+]
+
+[project.scripts]
+{{ cookiecutter.project_slug }} = "{{ cookiecutter.project_slug }}.cli:main"
+
+[project.urls]
+Homepage = "https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}"
+Repository = "https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}"
+Issues = "https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}/issues"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.black]
+line-length = 88
+target-version = ["py{{ cookiecutter.python_version.replace('.', '') }}"]
+
+[tool.mypy]
+python_version = "{{ cookiecutter.python_version }}"
+strict = true
+warn_return_any = true
+warn_unused_configs = true
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+python_functions = ["test_*"]
+addopts = [
+    "--strict-markers",
+    "--strict-config",
+    "--cov=src/{{ cookiecutter.project_slug }}",
+    "--cov-report=term-missing",
+    "--cov-report=html",
+    "--cov-fail-under=80"
+]

--- a/egile_mcp_starter/templates/rag/{{cookiecutter.project_slug}}/src/main.py
+++ b/egile_mcp_starter/templates/rag/{{cookiecutter.project_slug}}/src/main.py
@@ -1,0 +1,29 @@
+"""Main entry point for the RAG MCP server."""
+
+import asyncio
+import os
+from pathlib import Path
+
+from .server import create_rag_server
+
+
+async def main():
+    """Run the RAG MCP server."""
+    # Get configuration path from environment or use default
+    config_path = os.getenv("CONFIG_PATH", "config.yaml")
+
+    if not Path(config_path).exists():
+        print(f"Configuration file not found: {config_path}")
+        print("Please copy config.example.yaml to config.yaml and configure it.")
+        return
+
+    # Create and run the server
+    server = create_rag_server(config_path)
+
+    # Run the server
+    async with server:
+        await server.run()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/egile_mcp_starter/templates/rag/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/config.py
+++ b/egile_mcp_starter/templates/rag/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/config.py
@@ -16,12 +16,14 @@ class VectorDBConfig(BaseModel):
     """Configuration for vector database."""
     type: str
     path: Optional[str] = None
+    database_url: Optional[str] = None  # For FAISS, Chroma, etc.
     collection_name: str = "documents"
     api_key: Optional[str] = None
     environment: Optional[str] = None
     index_name: Optional[str] = None
     url: Optional[str] = None
     class_name: Optional[str] = None
+    dimension: Optional[int] = None  # For FAISS and other vector stores
 
 
 class ChunkingConfig(BaseModel):

--- a/egile_mcp_starter/templates/rag/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/config.py
+++ b/egile_mcp_starter/templates/rag/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/config.py
@@ -1,0 +1,113 @@
+"""Configuration management for RAG MCP server."""
+
+from typing import Any, Dict, Optional
+from pydantic import BaseModel
+
+
+class EmbeddingConfig(BaseModel):
+    """Configuration for embedding models."""
+    model: str
+    model_name: Optional[str] = None
+    api_key: Optional[str] = None
+    device: str = "cpu"
+
+
+class VectorDBConfig(BaseModel):
+    """Configuration for vector database."""
+    type: str
+    path: Optional[str] = None
+    collection_name: str = "documents"
+    api_key: Optional[str] = None
+    environment: Optional[str] = None
+    index_name: Optional[str] = None
+    url: Optional[str] = None
+    class_name: Optional[str] = None
+
+
+class ChunkingConfig(BaseModel):
+    """Configuration for text chunking."""
+    strategy: str = "recursive"
+    chunk_size: int = 1000
+    chunk_overlap: int = 200
+    similarity_threshold: Optional[float] = None
+    separators: Optional[list] = None
+
+
+{% if cookiecutter.include_reranker == 'y' %}
+class RerankerConfig(BaseModel):
+    """Configuration for reranking."""
+    enabled: bool = True
+    model: str = "cross-encoder/ms-marco-MiniLM-L-6-v2"
+    top_k: int = 10
+    score_threshold: float = 0.3
+{% endif %}
+
+
+{% if cookiecutter.web_scraping == 'y' %}
+class WebScrapingConfig(BaseModel):
+    """Configuration for web scraping."""
+    user_agent: str = "{{ cookiecutter.project_slug }}/{{ cookiecutter.version }}"
+    max_pages: int = 100
+    delay: float = 1.0
+    timeout: int = 30
+{% endif %}
+
+
+{% if cookiecutter.pdf_processing == 'y' %}
+class PDFProcessingConfig(BaseModel):
+    """Configuration for PDF processing."""
+    extract_images: bool = False
+    preserve_layout: bool = True
+    password: Optional[str] = None
+{% endif %}
+
+
+class DocumentProcessingConfig(BaseModel):
+    """Configuration for document processing."""
+    max_file_size: int = 10485760  # 10MB
+    allowed_extensions: list = [".txt", ".md", ".rst"]
+    ignore_patterns: list = ["*.tmp", "*.log", "__pycache__/*"]
+
+
+class SearchConfig(BaseModel):
+    """Configuration for search functionality."""
+    default_limit: int = 10
+    max_limit: int = 100
+    similarity_threshold: float = 0.7
+    {% if cookiecutter.include_reranker == 'y' %}
+    use_reranking: bool = True
+    {% endif %}
+
+
+class CacheConfig(BaseModel):
+    """Configuration for caching."""
+    enabled: bool = True
+    ttl: int = 3600  # 1 hour
+    max_size: int = 1000
+
+
+class ServerConfig(BaseModel):
+    """Configuration for the server."""
+    host: str = "localhost"
+    port: int = 8000
+    log_level: str = "INFO"
+
+
+class RAGConfig(BaseModel):
+    """Main configuration for RAG MCP server."""
+    server: ServerConfig
+    vector_db: VectorDBConfig
+    embedding: EmbeddingConfig
+    chunking: ChunkingConfig
+    {% if cookiecutter.include_reranker == 'y' %}
+    reranker: RerankerConfig
+    {% endif %}
+    {% if cookiecutter.web_scraping == 'y' %}
+    web_scraping: WebScrapingConfig
+    {% endif %}
+    {% if cookiecutter.pdf_processing == 'y' %}
+    pdf_processing: PDFProcessingConfig
+    {% endif %}
+    document_processing: DocumentProcessingConfig
+    search: SearchConfig
+    cache: CacheConfig

--- a/egile_mcp_starter/templates/rag/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/server.py
+++ b/egile_mcp_starter/templates/rag/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/server.py
@@ -1,0 +1,310 @@
+"""RAG MCP server implementation."""
+
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import yaml
+from fastmcp import FastMCP
+
+from .config import RAGConfig
+from .embeddings import EmbeddingManager
+from .vector_store import VectorStoreManager
+from .document_processor import DocumentProcessor
+{% if cookiecutter.include_reranker == 'y' %}
+from .reranker import RerankerManager
+{% endif %}
+
+
+logger = logging.getLogger(__name__)
+
+
+def create_rag_server(config_path: str) -> FastMCP:
+    """Create a RAG MCP server instance.
+    
+    Args:
+        config_path: Path to the configuration file
+        
+    Returns:
+        FastMCP server instance
+    """
+    # Load configuration
+    with open(config_path, 'r') as f:
+        config_dict = yaml.safe_load(f)
+    
+    config = RAGConfig(**config_dict)
+    
+    # Initialize components
+    embedding_manager = EmbeddingManager(config.embedding)
+    vector_store = VectorStoreManager(config.vector_db)
+    document_processor = DocumentProcessor(config.document_processing, config.chunking)
+    {% if cookiecutter.include_reranker == 'y' %}
+    reranker = RerankerManager(config.reranker) if config.reranker.enabled else None
+    {% endif %}
+    
+    # Create FastMCP server
+    server = FastMCP("{{ cookiecutter.project_name }}")
+    
+    @server.tool("ingest_documents")
+    async def ingest_documents(
+        documents: List[str], 
+        metadata: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        """Ingest documents into the vector database.
+        
+        Args:
+            documents: List of document paths or URLs to ingest
+            metadata: Optional metadata to associate with documents
+            
+        Returns:
+            Result of the ingestion process
+        """
+        try:
+            results = []
+            for doc_path in documents:
+                # Process document
+                chunks = await document_processor.process_document(doc_path)
+                
+                # Generate embeddings
+                embeddings = await embedding_manager.embed_texts([chunk.text for chunk in chunks])
+                
+                # Store in vector database
+                doc_metadata = metadata or {}
+                doc_metadata['source'] = doc_path
+                
+                chunk_ids = await vector_store.add_chunks(
+                    texts=[chunk.text for chunk in chunks],
+                    embeddings=embeddings,
+                    metadata=[{**doc_metadata, **chunk.metadata} for chunk in chunks]
+                )
+                
+                results.append({
+                    'document': doc_path,
+                    'chunks_added': len(chunk_ids),
+                    'chunk_ids': chunk_ids
+                })
+            
+            return {
+                'status': 'success',
+                'documents_processed': len(results),
+                'results': results
+            }
+            
+        except Exception as e:
+            logger.error(f"Error ingesting documents: {e}")
+            return {
+                'status': 'error',
+                'message': str(e)
+            }
+    
+    @server.tool("search_documents")
+    async def search_documents(
+        query: str,
+        limit: int = 10,
+        similarity_threshold: float = 0.7,
+        {% if cookiecutter.include_reranker == 'y' %}
+        use_reranking: bool = True
+        {% endif %}
+    ) -> Dict[str, Any]:
+        """Search for relevant documents using semantic similarity.
+        
+        Args:
+            query: Search query
+            limit: Maximum number of results to return
+            similarity_threshold: Minimum similarity score for results
+            {% if cookiecutter.include_reranker == 'y' %}
+            use_reranking: Whether to apply reranking to improve results
+            {% endif %}
+            
+        Returns:
+            Search results with relevance scores
+        """
+        try:
+            # Generate query embedding
+            query_embedding = await embedding_manager.embed_text(query)
+            
+            # Search vector database
+            search_limit = limit
+            {% if cookiecutter.include_reranker == 'y' %}
+            if use_reranking and reranker:
+                search_limit = min(limit * 3, 50)  # Get more results for reranking
+            {% endif %}
+            
+            results = await vector_store.search(
+                query_embedding=query_embedding,
+                limit=search_limit,
+                similarity_threshold=similarity_threshold
+            )
+            
+            {% if cookiecutter.include_reranker == 'y' %}
+            # Apply reranking if enabled
+            if use_reranking and reranker and results:
+                results = await reranker.rerank(query, results, limit)
+            {% endif %}
+            
+            return {
+                'status': 'success',
+                'query': query,
+                'results_count': len(results),
+                'results': [
+                    {
+                        'text': result.text,
+                        'score': result.score,
+                        'metadata': result.metadata
+                    }
+                    for result in results[:limit]
+                ]
+            }
+            
+        except Exception as e:
+            logger.error(f"Error searching documents: {e}")
+            return {
+                'status': 'error',
+                'message': str(e)
+            }
+    
+    @server.tool("get_document_chunks")
+    async def get_document_chunks(
+        document_id: str,
+        limit: int = 10
+    ) -> Dict[str, Any]:
+        """Get chunks from a specific document.
+        
+        Args:
+            document_id: ID of the document
+            limit: Maximum number of chunks to return
+            
+        Returns:
+            Document chunks
+        """
+        try:
+            chunks = await vector_store.get_document_chunks(document_id, limit)
+            
+            return {
+                'status': 'success',
+                'document_id': document_id,
+                'chunks_count': len(chunks),
+                'chunks': [
+                    {
+                        'text': chunk.text,
+                        'metadata': chunk.metadata
+                    }
+                    for chunk in chunks
+                ]
+            }
+            
+        except Exception as e:
+            logger.error(f"Error getting document chunks: {e}")
+            return {
+                'status': 'error',
+                'message': str(e)
+            }
+    
+    {% if cookiecutter.web_scraping == 'y' %}
+    @server.tool("scrape_and_index")
+    async def scrape_and_index(
+        urls: List[str],
+        metadata: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        """Scrape web pages and add them to the index.
+        
+        Args:
+            urls: List of URLs to scrape and index
+            metadata: Optional metadata to associate with scraped content
+            
+        Returns:
+            Result of the scraping and indexing process
+        """
+        try:
+            from .web_scraper import WebScraper
+            
+            scraper = WebScraper(config.web_scraping)
+            results = []
+            
+            for url in urls:
+                # Scrape content
+                content = await scraper.scrape_url(url)
+                
+                if content:
+                    # Process as document
+                    chunks = await document_processor.process_text(content, {'source_url': url})
+                    
+                    # Generate embeddings
+                    embeddings = await embedding_manager.embed_texts([chunk.text for chunk in chunks])
+                    
+                    # Store in vector database
+                    doc_metadata = metadata or {}
+                    doc_metadata.update({'source': url, 'type': 'web_page'})
+                    
+                    chunk_ids = await vector_store.add_chunks(
+                        texts=[chunk.text for chunk in chunks],
+                        embeddings=embeddings,
+                        metadata=[{**doc_metadata, **chunk.metadata} for chunk in chunks]
+                    )
+                    
+                    results.append({
+                        'url': url,
+                        'chunks_added': len(chunk_ids),
+                        'chunk_ids': chunk_ids
+                    })
+                else:
+                    results.append({
+                        'url': url,
+                        'error': 'Failed to scrape content'
+                    })
+            
+            return {
+                'status': 'success',
+                'urls_processed': len(results),
+                'results': results
+            }
+            
+        except Exception as e:
+            logger.error(f"Error scraping and indexing: {e}")
+            return {
+                'status': 'error',
+                'message': str(e)
+            }
+    {% endif %}
+    
+    # Resources
+    @server.resource("documents://list")
+    async def list_documents() -> str:
+        """List all indexed documents."""
+        try:
+            documents = await vector_store.list_documents()
+            return "\n".join([f"- {doc['id']}: {doc['metadata'].get('source', 'Unknown')}" for doc in documents])
+        except Exception as e:
+            return f"Error listing documents: {e}"
+    
+    @server.resource("documents://metadata/{doc_id}")
+    async def get_document_metadata(doc_id: str) -> str:
+        """Get metadata for a specific document."""
+        try:
+            metadata = await vector_store.get_document_metadata(doc_id)
+            if metadata:
+                return yaml.dump(metadata, default_flow_style=False)
+            else:
+                return f"Document {doc_id} not found"
+        except Exception as e:
+            return f"Error getting document metadata: {e}"
+    
+    @server.resource("chunks://search")
+    async def search_chunks(q: str) -> str:
+        """Search document chunks and return as formatted text."""
+        try:
+            result = await search_documents(q, limit=5)
+            if result['status'] == 'success':
+                chunks = []
+                for item in result['results']:
+                    chunks.append(f"Score: {item['score']:.3f}")
+                    chunks.append(f"Source: {item['metadata'].get('source', 'Unknown')}")
+                    chunks.append(f"Text: {item['text'][:200]}...")
+                    chunks.append("---")
+                return "\n".join(chunks)
+            else:
+                return f"Search error: {result['message']}"
+        except Exception as e:
+            return f"Error searching chunks: {e}"
+    
+    return server

--- a/egile_mcp_starter/templates/rag/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/vector_store.py
+++ b/egile_mcp_starter/templates/rag/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/vector_store.py
@@ -1,0 +1,682 @@
+"""Vector store implementation for different vector databases."""
+
+import logging
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+from pydantic import BaseModel
+
+from .config import VectorDBConfig
+
+logger = logging.getLogger(__name__)
+
+
+class SearchResult(BaseModel):
+    """Search result from vector store."""
+    
+    chunk_id: str
+    document_id: str
+    content: str
+    score: float
+    metadata: Dict[str, Any] = {}
+
+
+class VectorStore(ABC):
+    """Abstract base class for vector stores."""
+    
+    @abstractmethod
+    async def add_chunks(
+        self, 
+        chunks: List[Dict[str, Any]], 
+        embeddings: List[List[float]]
+    ) -> List[str]:
+        """Add chunks with embeddings to the vector store.
+        
+        Args:
+            chunks: List of chunk data with metadata
+            embeddings: List of embedding vectors
+            
+        Returns:
+            List of chunk IDs
+        """
+        pass
+    
+    @abstractmethod
+    async def search(
+        self, 
+        query_embedding: List[float], 
+        top_k: int = 10,
+        filters: Optional[Dict[str, Any]] = None
+    ) -> List[SearchResult]:
+        """Search for similar chunks.
+        
+        Args:
+            query_embedding: Query embedding vector
+            top_k: Number of results to return
+            filters: Optional metadata filters
+            
+        Returns:
+            List of search results
+        """
+        pass
+    
+    @abstractmethod
+    async def get_document_chunks(
+        self, 
+        document_id: str, 
+        limit: Optional[int] = None
+    ) -> List[Dict[str, Any]]:
+        """Get all chunks for a document.
+        
+        Args:
+            document_id: Document identifier
+            limit: Optional limit on number of chunks
+            
+        Returns:
+            List of chunk data
+        """
+        pass
+    
+    @abstractmethod
+    async def list_documents(self) -> List[Dict[str, Any]]:
+        """List all documents in the store.
+        
+        Returns:
+            List of document metadata
+        """
+        pass
+    
+    @abstractmethod
+    async def get_document_metadata(self, document_id: str) -> Dict[str, Any]:
+        """Get metadata for a document.
+        
+        Args:
+            document_id: Document identifier
+            
+        Returns:
+            Document metadata
+        """
+        pass
+
+
+{% if cookiecutter.vector_db == 'chroma' %}
+class ChromaVectorStore(VectorStore):
+    """ChromaDB vector store implementation."""
+    
+    def __init__(self, config: VectorDBConfig):
+        """Initialize ChromaDB vector store."""
+        import chromadb
+        from chromadb.config import Settings
+        
+        self.config = config
+        self.client = chromadb.PersistentClient(
+            path=config.database_url or "./chroma_db",
+            settings=Settings(allow_reset=True)
+        )
+        self.collection = self.client.get_or_create_collection(
+            name=config.collection_name or "documents"
+        )
+    
+    async def add_chunks(
+        self, 
+        chunks: List[Dict[str, Any]], 
+        embeddings: List[List[float]]
+    ) -> List[str]:
+        """Add chunks to ChromaDB."""
+        chunk_ids = [chunk['id'] for chunk in chunks]
+        documents = [chunk['content'] for chunk in chunks]
+        metadatas = [chunk.get('metadata', {}) for chunk in chunks]
+        
+        self.collection.add(
+            ids=chunk_ids,
+            documents=documents,
+            embeddings=embeddings,
+            metadatas=metadatas
+        )
+        
+        return chunk_ids
+    
+    async def search(
+        self, 
+        query_embedding: List[float], 
+        top_k: int = 10,
+        filters: Optional[Dict[str, Any]] = None
+    ) -> List[SearchResult]:
+        """Search ChromaDB for similar chunks."""
+        where = filters if filters else None
+        
+        results = self.collection.query(
+            query_embeddings=[query_embedding],
+            n_results=top_k,
+            where=where
+        )
+        
+        search_results = []
+        for i in range(len(results['ids'][0])):
+            search_results.append(SearchResult(
+                chunk_id=results['ids'][0][i],
+                document_id=results['metadatas'][0][i].get('document_id', ''),
+                content=results['documents'][0][i],
+                score=1.0 - results['distances'][0][i],  # Convert distance to similarity
+                metadata=results['metadatas'][0][i]
+            ))
+        
+        return search_results
+    
+    async def get_document_chunks(
+        self, 
+        document_id: str, 
+        limit: Optional[int] = None
+    ) -> List[Dict[str, Any]]:
+        """Get chunks for a document from ChromaDB."""
+        results = self.collection.get(
+            where={"document_id": document_id},
+            limit=limit
+        )
+        
+        chunks = []
+        for i in range(len(results['ids'])):
+            chunks.append({
+                'id': results['ids'][i],
+                'content': results['documents'][i],
+                'metadata': results['metadatas'][i]
+            })
+        
+        return chunks
+    
+    async def list_documents(self) -> List[Dict[str, Any]]:
+        """List all documents in ChromaDB."""
+        # ChromaDB doesn't have direct document listing, so we aggregate from chunks
+        results = self.collection.get()
+        document_ids = set()
+        
+        for metadata in results['metadatas']:
+            if 'document_id' in metadata:
+                document_ids.add(metadata['document_id'])
+        
+        return [{'id': doc_id} for doc_id in document_ids]
+    
+    async def get_document_metadata(self, document_id: str) -> Dict[str, Any]:
+        """Get document metadata from ChromaDB."""
+        results = self.collection.get(
+            where={"document_id": document_id},
+            limit=1
+        )
+        
+        if results['metadatas']:
+            return results['metadatas'][0]
+        return {}
+
+
+{% elif cookiecutter.vector_db == 'faiss' %}
+class FAISSVectorStore(VectorStore):
+    """FAISS vector store implementation."""
+    
+    def __init__(self, config: VectorDBConfig):
+        """Initialize FAISS vector store."""
+        import faiss
+        import pickle
+        
+        self.config = config
+        self.index_path = Path(config.database_url or "./faiss_index")
+        self.index_path.mkdir(exist_ok=True)
+        
+        self.index_file = self.index_path / "index.faiss"
+        self.metadata_file = self.index_path / "metadata.pkl"
+        
+        # Initialize or load index
+        self.dimension = config.dimension or 384  # Default for sentence-transformers
+        self.index = None
+        self.metadata_store = {}
+        self.chunk_counter = 0
+        
+        self._load_index()
+    
+    def _load_index(self):
+        """Load existing index or create new one."""
+        import faiss
+        import pickle
+        
+        if self.index_file.exists() and self.metadata_file.exists():
+            self.index = faiss.read_index(str(self.index_file))
+            with open(self.metadata_file, 'rb') as f:
+                self.metadata_store = pickle.load(f)
+            self.chunk_counter = len(self.metadata_store)
+        else:
+            self.index = faiss.IndexFlatIP(self.dimension)  # Inner product (cosine similarity)
+            self.metadata_store = {}
+            self.chunk_counter = 0
+    
+    def _save_index(self):
+        """Save index and metadata to disk."""
+        import faiss
+        import pickle
+        
+        faiss.write_index(self.index, str(self.index_file))
+        with open(self.metadata_file, 'wb') as f:
+            pickle.dump(self.metadata_store, f)
+    
+    async def add_chunks(
+        self, 
+        chunks: List[Dict[str, Any]], 
+        embeddings: List[List[float]]
+    ) -> List[str]:
+        """Add chunks to FAISS index."""
+        import numpy as np
+        
+        # Normalize embeddings for cosine similarity
+        embeddings_array = np.array(embeddings, dtype=np.float32)
+        embeddings_array = embeddings_array / np.linalg.norm(embeddings_array, axis=1, keepdims=True)
+        
+        # Add to index
+        self.index.add(embeddings_array)
+        
+        # Store metadata
+        chunk_ids = []
+        for i, chunk in enumerate(chunks):
+            chunk_id = chunk.get('id', f"chunk_{self.chunk_counter}")
+            chunk_ids.append(chunk_id)
+            
+            self.metadata_store[self.chunk_counter] = {
+                'chunk_id': chunk_id,
+                'document_id': chunk.get('document_id', ''),
+                'content': chunk.get('content', ''),
+                'metadata': chunk.get('metadata', {})
+            }
+            self.chunk_counter += 1
+        
+        self._save_index()
+        return chunk_ids
+    
+    async def search(
+        self, 
+        query_embedding: List[float], 
+        top_k: int = 10,
+        filters: Optional[Dict[str, Any]] = None
+    ) -> List[SearchResult]:
+        """Search FAISS index for similar chunks."""
+        import numpy as np
+        
+        if self.index.ntotal == 0:
+            return []
+        
+        # Normalize query embedding
+        query_array = np.array([query_embedding], dtype=np.float32)
+        query_array = query_array / np.linalg.norm(query_array, axis=1, keepdims=True)
+        
+        # Search
+        scores, indices = self.index.search(query_array, min(top_k, self.index.ntotal))
+        
+        search_results = []
+        for i, (score, idx) in enumerate(zip(scores[0], indices[0])):
+            if idx == -1:  # Invalid result
+                continue
+                
+            metadata_entry = self.metadata_store.get(idx, {})
+            
+            # Apply filters if provided
+            if filters:
+                match = True
+                for key, value in filters.items():
+                    if metadata_entry.get('metadata', {}).get(key) != value:
+                        match = False
+                        break
+                if not match:
+                    continue
+            
+            search_results.append(SearchResult(
+                chunk_id=metadata_entry.get('chunk_id', f'chunk_{idx}'),
+                document_id=metadata_entry.get('document_id', ''),
+                content=metadata_entry.get('content', ''),
+                score=float(score),
+                metadata=metadata_entry.get('metadata', {})
+            ))
+        
+        return search_results
+    
+    async def get_document_chunks(
+        self, 
+        document_id: str, 
+        limit: Optional[int] = None
+    ) -> List[Dict[str, Any]]:
+        """Get chunks for a document from FAISS store."""
+        chunks = []
+        count = 0
+        
+        for idx, metadata_entry in self.metadata_store.items():
+            if metadata_entry.get('document_id') == document_id:
+                chunks.append({
+                    'id': metadata_entry.get('chunk_id'),
+                    'content': metadata_entry.get('content'),
+                    'metadata': metadata_entry.get('metadata', {})
+                })
+                count += 1
+                
+                if limit and count >= limit:
+                    break
+        
+        return chunks
+    
+    async def list_documents(self) -> List[Dict[str, Any]]:
+        """List all documents in FAISS store."""
+        document_ids = set()
+        
+        for metadata_entry in self.metadata_store.values():
+            doc_id = metadata_entry.get('document_id')
+            if doc_id:
+                document_ids.add(doc_id)
+        
+        return [{'id': doc_id} for doc_id in document_ids]
+    
+    async def get_document_metadata(self, document_id: str) -> Dict[str, Any]:
+        """Get document metadata from FAISS store."""
+        for metadata_entry in self.metadata_store.values():
+            if metadata_entry.get('document_id') == document_id:
+                return metadata_entry.get('metadata', {})
+        
+        return {}
+
+
+{% elif cookiecutter.vector_db == 'pinecone' %}
+class PineconeVectorStore(VectorStore):
+    """Pinecone vector store implementation."""
+    
+    def __init__(self, config: VectorDBConfig):
+        """Initialize Pinecone vector store."""
+        import pinecone
+        
+        self.config = config
+        
+        # Initialize Pinecone
+        pinecone.init(
+            api_key=config.api_key,
+            environment=config.environment or 'us-west1-gcp'
+        )
+        
+        self.index_name = config.index_name or 'documents'
+        
+        # Create index if it doesn't exist
+        if self.index_name not in pinecone.list_indexes():
+            pinecone.create_index(
+                name=self.index_name,
+                dimension=config.dimension or 384,
+                metric='cosine'
+            )
+        
+        self.index = pinecone.Index(self.index_name)
+    
+    async def add_chunks(
+        self, 
+        chunks: List[Dict[str, Any]], 
+        embeddings: List[List[float]]
+    ) -> List[str]:
+        """Add chunks to Pinecone."""
+        vectors = []
+        chunk_ids = []
+        
+        for chunk, embedding in zip(chunks, embeddings):
+            chunk_id = chunk.get('id', f"chunk_{len(chunk_ids)}")
+            chunk_ids.append(chunk_id)
+            
+            metadata = chunk.get('metadata', {})
+            metadata.update({
+                'document_id': chunk.get('document_id', ''),
+                'content': chunk.get('content', '')
+            })
+            
+            vectors.append({
+                'id': chunk_id,
+                'values': embedding,
+                'metadata': metadata
+            })
+        
+        self.index.upsert(vectors)
+        return chunk_ids
+    
+    async def search(
+        self, 
+        query_embedding: List[float], 
+        top_k: int = 10,
+        filters: Optional[Dict[str, Any]] = None
+    ) -> List[SearchResult]:
+        """Search Pinecone for similar chunks."""
+        results = self.index.query(
+            vector=query_embedding,
+            top_k=top_k,
+            filter=filters,
+            include_metadata=True
+        )
+        
+        search_results = []
+        for match in results['matches']:
+            metadata = match.get('metadata', {})
+            search_results.append(SearchResult(
+                chunk_id=match['id'],
+                document_id=metadata.get('document_id', ''),
+                content=metadata.get('content', ''),
+                score=match['score'],
+                metadata={k: v for k, v in metadata.items() 
+                         if k not in ['document_id', 'content']}
+            ))
+        
+        return search_results
+    
+    async def get_document_chunks(
+        self, 
+        document_id: str, 
+        limit: Optional[int] = None
+    ) -> List[Dict[str, Any]]:
+        """Get chunks for a document from Pinecone."""
+        # Pinecone doesn't support direct filtering in fetch, so we use query
+        dummy_vector = [0.0] * (self.config.dimension or 384)
+        
+        results = self.index.query(
+            vector=dummy_vector,
+            top_k=limit or 10000,  # Large number to get all
+            filter={'document_id': document_id},
+            include_metadata=True
+        )
+        
+        chunks = []
+        for match in results['matches']:
+            metadata = match.get('metadata', {})
+            chunks.append({
+                'id': match['id'],
+                'content': metadata.get('content', ''),
+                'metadata': {k: v for k, v in metadata.items() 
+                           if k not in ['document_id', 'content']}
+            })
+        
+        return chunks
+    
+    async def list_documents(self) -> List[Dict[str, Any]]:
+        """List all documents in Pinecone."""
+        # This is a limitation of Pinecone - we can't easily list all unique document_ids
+        # This would require maintaining a separate index or using describe_index_stats
+        stats = self.index.describe_index_stats()
+        return [{'note': 'Document listing not fully supported by Pinecone'}]
+    
+    async def get_document_metadata(self, document_id: str) -> Dict[str, Any]:
+        """Get document metadata from Pinecone."""
+        # Similar limitation - we'd need to store document metadata separately
+        # or query for any chunk from the document
+        dummy_vector = [0.0] * (self.config.dimension or 384)
+        
+        results = self.index.query(
+            vector=dummy_vector,
+            top_k=1,
+            filter={'document_id': document_id},
+            include_metadata=True
+        )
+        
+        if results['matches']:
+            return results['matches'][0].get('metadata', {})
+        return {}
+
+
+{% else %}
+# Default/fallback implementation for other vector stores
+class DefaultVectorStore(VectorStore):
+    """Default in-memory vector store implementation."""
+    
+    def __init__(self, config: VectorDBConfig):
+        """Initialize default vector store."""
+        self.config = config
+        self.chunks = []
+        self.embeddings = []
+    
+    async def add_chunks(
+        self, 
+        chunks: List[Dict[str, Any]], 
+        embeddings: List[List[float]]
+    ) -> List[str]:
+        """Add chunks to in-memory store."""
+        chunk_ids = []
+        for chunk, embedding in zip(chunks, embeddings):
+            chunk_id = chunk.get('id', f"chunk_{len(self.chunks)}")
+            chunk_ids.append(chunk_id)
+            
+            self.chunks.append({
+                'id': chunk_id,
+                'document_id': chunk.get('document_id', ''),
+                'content': chunk.get('content', ''),
+                'metadata': chunk.get('metadata', {})
+            })
+            self.embeddings.append(embedding)
+        
+        return chunk_ids
+    
+    async def search(
+        self, 
+        query_embedding: List[float], 
+        top_k: int = 10,
+        filters: Optional[Dict[str, Any]] = None
+    ) -> List[SearchResult]:
+        """Search in-memory store for similar chunks."""
+        import numpy as np
+        
+        if not self.embeddings:
+            return []
+        
+        # Calculate cosine similarities
+        query_array = np.array(query_embedding)
+        embeddings_array = np.array(self.embeddings)
+        
+        # Normalize vectors
+        query_norm = query_array / np.linalg.norm(query_array)
+        embeddings_norm = embeddings_array / np.linalg.norm(embeddings_array, axis=1, keepdims=True)
+        
+        # Calculate similarities
+        similarities = np.dot(embeddings_norm, query_norm)
+        
+        # Get top-k indices
+        top_indices = np.argsort(similarities)[::-1][:top_k]
+        
+        search_results = []
+        for idx in top_indices:
+            chunk = self.chunks[idx]
+            
+            # Apply filters if provided
+            if filters:
+                match = True
+                for key, value in filters.items():
+                    if chunk.get('metadata', {}).get(key) != value:
+                        match = False
+                        break
+                if not match:
+                    continue
+            
+            search_results.append(SearchResult(
+                chunk_id=chunk['id'],
+                document_id=chunk['document_id'],
+                content=chunk['content'],
+                score=float(similarities[idx]),
+                metadata=chunk.get('metadata', {})
+            ))
+        
+        return search_results
+    
+    async def get_document_chunks(
+        self, 
+        document_id: str, 
+        limit: Optional[int] = None
+    ) -> List[Dict[str, Any]]:
+        """Get chunks for a document from in-memory store."""
+        chunks = [chunk for chunk in self.chunks if chunk['document_id'] == document_id]
+        
+        if limit:
+            chunks = chunks[:limit]
+        
+        return chunks
+    
+    async def list_documents(self) -> List[Dict[str, Any]]:
+        """List all documents in in-memory store."""
+        document_ids = set(chunk['document_id'] for chunk in self.chunks if chunk['document_id'])
+        return [{'id': doc_id} for doc_id in document_ids]
+    
+    async def get_document_metadata(self, document_id: str) -> Dict[str, Any]:
+        """Get document metadata from in-memory store."""
+        for chunk in self.chunks:
+            if chunk['document_id'] == document_id:
+                return chunk.get('metadata', {})
+        return {}
+
+{% endif %}
+
+
+class VectorStoreManager:
+    """Manager for vector store operations."""
+    
+    def __init__(self, config: VectorDBConfig):
+        """Initialize vector store manager.
+        
+        Args:
+            config: Vector database configuration
+        """
+        self.config = config
+        
+        # Initialize the appropriate vector store
+        {% if cookiecutter.vector_db == 'chroma' %}
+        self.store = ChromaVectorStore(config)
+        {% elif cookiecutter.vector_db == 'faiss' %}
+        self.store = FAISSVectorStore(config)
+        {% elif cookiecutter.vector_db == 'pinecone' %}
+        self.store = PineconeVectorStore(config)
+        {% else %}
+        self.store = DefaultVectorStore(config)
+        {% endif %}
+    
+    async def add_chunks(
+        self, 
+        chunks: List[Dict[str, Any]], 
+        embeddings: List[List[float]]
+    ) -> List[str]:
+        """Add chunks with embeddings to the vector store."""
+        return await self.store.add_chunks(chunks, embeddings)
+    
+    async def search(
+        self, 
+        query_embedding: List[float], 
+        top_k: int = 10,
+        filters: Optional[Dict[str, Any]] = None
+    ) -> List[SearchResult]:
+        """Search for similar chunks."""
+        return await self.store.search(query_embedding, top_k, filters)
+    
+    async def get_document_chunks(
+        self, 
+        document_id: str, 
+        limit: Optional[int] = None
+    ) -> List[Dict[str, Any]]:
+        """Get all chunks for a document."""
+        return await self.store.get_document_chunks(document_id, limit)
+    
+    async def list_documents(self) -> List[Dict[str, Any]]:
+        """List all documents in the store."""
+        return await self.store.list_documents()
+    
+    async def get_document_metadata(self, document_id: str) -> Dict[str, Any]:
+        """Get metadata for a document."""
+        return await self.store.get_document_metadata(document_id)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,12 +4,12 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "egile-mcp-starter"
-version = "0.1.0"
-description = "A comprehensive cookiecutter template for creating Model Context Protocol (MCP) servers using the FASTMCP framework"
+version = "0.2.0"
+description = "A comprehensive and extensible cookiecutter template system for creating Model Context Protocol (MCP) servers with plugin architecture supporting multiple templates including RAG-enabled servers"
 authors = [{name = "Jean-Baptiste Poullet", email = "egile@gmail.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
-keywords = ["mcp", "model-context-protocol", "fastmcp", "cookiecutter", "template", "ai", "assistant"]
+keywords = ["mcp", "model-context-protocol", "fastmcp", "cookiecutter", "template", "ai", "assistant", "rag", "retrieval-augmented-generation", "vector-database", "plugin-architecture", "chroma", "pinecone", "faiss", "embedding"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
@@ -44,6 +44,9 @@ packages = [{include = "egile_mcp_starter"}]
 include = [
     "egile_mcp_starter/template/**/*",
     "egile_mcp_starter/template/**/.*",
+    "egile_mcp_starter/templates/**/*",
+    "egile_mcp_starter/templates/**/.*",
+    "egile_mcp_starter/plugins/**/*",
 ]
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,7 @@ warn_unreachable = true
 strict_equality = true
 exclude = [
     "egile_mcp_starter/template/",
+    "egile_mcp_starter/templates/",
 ]
 
 [[tool.mypy.overrides]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ extend-exclude = '''
   | build
   | dist
   | egile_mcp_starter/template
+  | egile_mcp_starter/templates
 )/
 '''
 
@@ -89,7 +90,7 @@ profile = "black"
 multi_line_output = 3
 line_length = 88
 known_first_party = ["egile_mcp_starter"]
-skip_glob = ["egile_mcp_starter/template/**/*"]
+skip_glob = ["egile_mcp_starter/template/**/*", "egile_mcp_starter/templates/**/*"]
 
 [tool.mypy]
 python_version = "3.10"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -38,6 +38,7 @@ class TestCLI:
             config_file=None,
             default_config=False,
             verbose=False,
+            template="mcp",  # Added template parameter
         )
         mock_generator.generate.assert_called_once()
 
@@ -60,6 +61,7 @@ class TestCLI:
             config_file=None,
             default_config=False,
             verbose=True,
+            template="mcp",  # Added template parameter
         )
 
     @patch("egile_mcp_starter.cli.MCPProjectGenerator")
@@ -75,8 +77,8 @@ class TestCLI:
         assert result.exit_code == 0
         assert "MCP server project generated successfully" in result.output
         assert "Next steps:" in result.output
-        assert "cd /tmp/test-project" in result.output
-        assert "poetry install" in result.output
+        assert "cd test-project" in result.output  # Fixed to use project name only
+        assert "pip install -e ." in result.output
 
     @patch("egile_mcp_starter.cli.MCPProjectGenerator")
     def test_cli_error_handling(self, mock_generator_class):
@@ -93,7 +95,7 @@ class TestCLI:
         print(f"Exception: {result.exception}")
 
         assert result.exit_code == 1
-        assert "Error generating project: Test error" in result.output
+        assert "❌ Error: Test error" in result.output
 
     @patch("egile_mcp_starter.cli.MCPProjectGenerator")
     def test_cli_with_config_file(self, mock_generator_class):
@@ -117,4 +119,5 @@ class TestCLI:
                 config_file="test-config.yaml",
                 default_config=False,
                 verbose=False,
+                template="mcp",  # Added template parameter
             )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -38,7 +38,8 @@ class TestCLI:
             config_file=None,
             default_config=False,
             verbose=False,
-            template="mcp",  # Added template parameter
+            template="mcp",
+            project_name=None,
         )
         mock_generator.generate.assert_called_once()
 
@@ -61,7 +62,8 @@ class TestCLI:
             config_file=None,
             default_config=False,
             verbose=True,
-            template="mcp",  # Added template parameter
+            template="mcp",
+            project_name=None,
         )
 
     @patch("egile_mcp_starter.cli.MCPProjectGenerator")
@@ -119,5 +121,6 @@ class TestCLI:
                 config_file="test-config.yaml",
                 default_config=False,
                 verbose=False,
-                template="mcp",  # Added template parameter
+                template="mcp",
+                project_name=None,
             )

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -20,7 +20,7 @@ class TestMCPProjectGenerator:
         assert generator.no_input is False
         assert generator.config_file is None
         assert generator.verbose is False
-        assert generator.template_dir.exists()
+        assert generator.template_name == "mcp"  # Default template
 
     def test_generator_with_custom_params(self):
         """Test generator with custom parameters."""
@@ -43,7 +43,7 @@ class TestMCPProjectGenerator:
         assert "project_slug" in context
         assert "author_name" in context
         assert "python_version" in context
-        assert context["project_name"] == "my-mcp-server"
+        assert context["project_name"] == "My MCP Server"  # Updated default value
         assert context["python_version"] == "3.11"
 
     @patch("egile_mcp_starter.generator.cookiecutter")

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,372 @@
+"""Test the plugin system functionality."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from egile_mcp_starter.generator import MCPProjectGenerator
+from egile_mcp_starter.plugins.base import TemplatePlugin
+from egile_mcp_starter.plugins.registry import TemplateRegistry, get_registry
+from egile_mcp_starter.plugins.builtin.mcp_template import MCPTemplatePlugin
+from egile_mcp_starter.plugins.builtin.rag_template import RAGTemplatePlugin
+
+
+class TestTemplatePlugin:
+    """Test the base TemplatePlugin class."""
+
+    def test_template_plugin_interface(self):
+        """Test that TemplatePlugin defines the correct interface."""
+        # Check that TemplatePlugin is abstract and cannot be instantiated
+        with pytest.raises(TypeError):
+            TemplatePlugin("test", "Test template")
+
+    def test_template_plugin_inheritance(self):
+        """Test that built-in plugins properly inherit from TemplatePlugin."""
+        mcp_plugin = MCPTemplatePlugin()
+        rag_plugin = RAGTemplatePlugin()
+
+        assert isinstance(mcp_plugin, TemplatePlugin)
+        assert isinstance(rag_plugin, TemplatePlugin)
+
+
+class TestTemplateRegistry:
+    """Test the template registry functionality."""
+
+    def setup_method(self):
+        """Set up a fresh registry for each test."""
+        self.registry = TemplateRegistry()
+
+    def test_registry_initialization(self):
+        """Test that registry initializes with built-in templates."""
+        assert len(self.registry.list_plugins()) >= 2  # At least MCP and RAG
+        plugin_names = self.registry.get_plugin_names()
+        assert "mcp" in plugin_names
+        assert "rag" in plugin_names
+
+    def test_get_plugin(self):
+        """Test getting plugins by name."""
+        mcp_plugin = self.registry.get_plugin("mcp")
+        rag_plugin = self.registry.get_plugin("rag")
+        nonexistent_plugin = self.registry.get_plugin("nonexistent")
+
+        assert mcp_plugin is not None
+        assert isinstance(mcp_plugin, MCPTemplatePlugin)
+        assert rag_plugin is not None
+        assert isinstance(rag_plugin, RAGTemplatePlugin)
+        assert nonexistent_plugin is None
+
+    def test_register_custom_plugin(self):
+        """Test registering a custom plugin."""
+
+        class TestPlugin(TemplatePlugin):
+            def __init__(self):
+                super().__init__("test", "Test plugin", "1.0.0")
+
+            def get_template_path(self) -> Path:
+                return Path("/tmp/test")
+
+            def get_default_context(self) -> dict:
+                return {"test": "value"}
+
+        test_plugin = TestPlugin()
+        initial_count = len(self.registry.list_plugins())
+
+        self.registry.register(test_plugin)
+
+        assert len(self.registry.list_plugins()) == initial_count + 1
+        assert self.registry.get_plugin("test") == test_plugin
+
+    def test_register_duplicate_plugin_raises_error(self):
+        """Test that registering a plugin with duplicate name raises error."""
+
+        class TestPlugin(TemplatePlugin):
+            def __init__(self):
+                super().__init__("mcp", "Duplicate MCP plugin", "1.0.0")
+
+            def get_template_path(self) -> Path:
+                return Path("/tmp/test")
+
+            def get_default_context(self) -> dict:
+                return {"test": "value"}
+
+        test_plugin = TestPlugin()
+
+        with pytest.raises(ValueError, match="already registered"):
+            self.registry.register(test_plugin)
+
+    def test_unregister_plugin(self):
+        """Test unregistering a plugin."""
+        initial_count = len(self.registry.list_plugins())
+
+        self.registry.unregister("mcp")
+
+        assert len(self.registry.list_plugins()) == initial_count - 1
+        assert self.registry.get_plugin("mcp") is None
+
+    def test_global_registry(self):
+        """Test that get_registry returns the same instance."""
+        registry1 = get_registry()
+        registry2 = get_registry()
+
+        assert registry1 is registry2
+
+
+class TestMCPTemplatePlugin:
+    """Test the MCP template plugin."""
+
+    def setup_method(self):
+        """Set up MCP plugin for testing."""
+        self.plugin = MCPTemplatePlugin()
+
+    def test_plugin_properties(self):
+        """Test plugin basic properties."""
+        assert self.plugin.name == "mcp"
+        assert "MCP server" in self.plugin.description
+        assert self.plugin.version == "1.0.0"
+
+    def test_template_path(self):
+        """Test that template path exists."""
+        template_path = self.plugin.get_template_path()
+        assert template_path.exists()
+        assert (template_path / "cookiecutter.json").exists()
+
+    def test_default_context(self):
+        """Test default context has required fields."""
+        context = self.plugin.get_default_context()
+        required_fields = ["project_name", "author_name", "author_email"]
+
+        for field in required_fields:
+            assert field in context
+            assert context[field]  # Check it's not empty
+
+    def test_supported_features(self):
+        """Test supported features list."""
+        features = self.plugin.get_supported_features()
+        expected_features = ["docker", "github_actions", "testing"]
+
+        for feature in expected_features:
+            assert feature in features
+
+    def test_validate_context(self):
+        """Test context validation."""
+        valid_context = {
+            "project_name": "Test Project",
+            "author_name": "Test Author",
+            "author_email": "test@example.com",
+        }
+        invalid_context = {
+            "project_name": "Test Project"
+            # Missing required fields
+        }
+
+        assert self.plugin.validate_context(valid_context) is True
+        assert self.plugin.validate_context(invalid_context) is False
+
+    def test_pre_generate_hook(self):
+        """Test pre-generation hook."""
+        context = {"project_name": "Test Project"}
+        modified_context = self.plugin.pre_generate_hook(context)
+
+        assert "project_slug" in modified_context
+        assert modified_context["project_slug"] == "test_project"
+
+    def test_post_generate_hook(self):
+        """Test post-generation hook (should not raise exceptions)."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            project_path = Path(tmp_dir)
+            context = {"project_name": "Test Project"}
+
+            # Should not raise any exceptions
+            self.plugin.post_generate_hook(project_path, context)
+
+
+class TestRAGTemplatePlugin:
+    """Test the RAG template plugin."""
+
+    def setup_method(self):
+        """Set up RAG plugin for testing."""
+        self.plugin = RAGTemplatePlugin()
+
+    def test_plugin_properties(self):
+        """Test plugin basic properties."""
+        assert self.plugin.name == "rag"
+        assert "RAG" in self.plugin.description
+        assert self.plugin.version == "1.0.0"
+
+    def test_template_path(self):
+        """Test that template path exists."""
+        template_path = self.plugin.get_template_path()
+        assert template_path.exists()
+        assert (template_path / "cookiecutter.json").exists()
+
+    def test_default_context(self):
+        """Test default context has RAG-specific fields."""
+        context = self.plugin.get_default_context()
+        rag_fields = ["vector_db", "embedding_model", "chunk_strategy"]
+
+        for field in rag_fields:
+            assert field in context
+            assert context[field]  # Check it's not empty
+
+    def test_supported_features(self):
+        """Test RAG-specific supported features."""
+        features = self.plugin.get_supported_features()
+        rag_features = ["vector_databases", "embedding_models", "semantic_search"]
+
+        for feature in rag_features:
+            assert feature in features
+
+    def test_validate_context(self):
+        """Test RAG-specific context validation."""
+        valid_context = {
+            "project_name": "Test RAG Project",
+            "author_name": "Test Author",
+            "author_email": "test@example.com",
+            "vector_db": "chroma",
+            "embedding_model": "sentence-transformers",
+        }
+        invalid_vector_db = {
+            "project_name": "Test RAG Project",
+            "author_name": "Test Author",
+            "author_email": "test@example.com",
+            "vector_db": "invalid_db",
+            "embedding_model": "sentence-transformers",
+        }
+        invalid_embedding = {
+            "project_name": "Test RAG Project",
+            "author_name": "Test Author",
+            "author_email": "test@example.com",
+            "vector_db": "chroma",
+            "embedding_model": "invalid_model",
+        }
+
+        assert self.plugin.validate_context(valid_context) is True
+        assert self.plugin.validate_context(invalid_vector_db) is False
+        assert self.plugin.validate_context(invalid_embedding) is False
+
+    def test_pre_generate_hook_dependencies(self):
+        """Test that pre-generation hook computes dependencies correctly."""
+        context = {
+            "project_name": "Test RAG Project",
+            "vector_db": "chroma",
+            "embedding_model": "sentence-transformers",
+            "pdf_processing": "y",
+            "web_scraping": "y",
+        }
+
+        modified_context = self.plugin.pre_generate_hook(context)
+        dependencies = modified_context["_computed_dependencies"]
+
+        # Check base dependencies
+        assert "fastmcp" in dependencies
+        assert "pydantic" in dependencies
+
+        # Check vector DB specific dependencies
+        assert "chromadb" in dependencies
+
+        # Check embedding model dependencies
+        assert "sentence-transformers" in dependencies
+
+        # Check optional feature dependencies
+        assert "pypdf2" in dependencies  # PDF processing
+        assert "requests" in dependencies  # Web scraping
+
+
+class TestGeneratorWithPlugins:
+    """Test the generator with plugin system integration."""
+
+    def test_generator_with_template_parameter(self):
+        """Test generator accepts template parameter."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            # Test MCP template
+            mcp_generator = MCPProjectGenerator(
+                output_dir=tmp_dir, template="mcp", no_input=True
+            )
+            assert mcp_generator.template_name == "mcp"
+
+            # Test RAG template
+            rag_generator = MCPProjectGenerator(
+                output_dir=tmp_dir, template="rag", no_input=True
+            )
+            assert rag_generator.template_name == "rag"
+
+    def test_generator_with_invalid_template(self):
+        """Test generator raises error with invalid template."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with pytest.raises(ValueError, match="Template 'invalid' not found"):
+                MCPProjectGenerator(output_dir=tmp_dir, template="invalid")
+
+    def test_list_available_templates(self):
+        """Test generator can list available templates."""
+        generator = MCPProjectGenerator(template="mcp")
+        templates = generator.list_available_templates()
+
+        assert "mcp" in templates
+        assert "rag" in templates
+        assert len(templates) >= 2
+
+    def test_get_default_context_from_plugin(self):
+        """Test generator gets default context from plugin."""
+        mcp_generator = MCPProjectGenerator(template="mcp")
+        rag_generator = MCPProjectGenerator(template="rag")
+
+        mcp_context = mcp_generator.get_default_context()
+        rag_context = rag_generator.get_default_context()
+
+        # MCP should have server_type, RAG should have vector_db
+        assert "server_type" in mcp_context
+        assert "vector_db" in rag_context
+
+
+class TestPluginSystemIntegration:
+    """Integration tests for the entire plugin system."""
+
+    def test_plugin_discovery(self):
+        """Test that plugins are automatically discovered."""
+        registry = get_registry()
+        plugins = registry.list_plugins()
+
+        # Should have at least MCP and RAG templates
+        assert len(plugins) >= 2
+
+        plugin_names = [p.name for p in plugins]
+        assert "mcp" in plugin_names
+        assert "rag" in plugin_names
+
+    def test_end_to_end_plugin_workflow(self):
+        """Test complete workflow from plugin selection to context generation."""
+        registry = get_registry()
+
+        # Get a plugin
+        plugin = registry.get_plugin("rag")
+        assert plugin is not None
+
+        # Get default context
+        context = plugin.get_default_context()
+        assert context is not None
+
+        # Validate context
+        assert plugin.validate_context(context) is True
+
+        # Apply pre-generation hook
+        modified_context = plugin.pre_generate_hook(context)
+        assert "_computed_dependencies" in modified_context
+
+        # Get template path
+        template_path = plugin.get_template_path()
+        assert template_path.exists()
+
+    @pytest.mark.skipif(
+        not Path("egile_mcp_starter/template").exists(),
+        reason="Original template directory not found",
+    )
+    def test_backward_compatibility(self):
+        """Test that original template still works through plugin system."""
+        registry = get_registry()
+        mcp_plugin = registry.get_plugin("mcp")
+
+        # Should use the original template directory
+        template_path = mcp_plugin.get_template_path()
+        assert template_path.name == "template"
+        assert (template_path / "cookiecutter.json").exists()

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -7,9 +7,9 @@ import pytest
 
 from egile_mcp_starter.generator import MCPProjectGenerator
 from egile_mcp_starter.plugins.base import TemplatePlugin
-from egile_mcp_starter.plugins.registry import TemplateRegistry, get_registry
 from egile_mcp_starter.plugins.builtin.mcp_template import MCPTemplatePlugin
 from egile_mcp_starter.plugins.builtin.rag_template import RAGTemplatePlugin
+from egile_mcp_starter.plugins.registry import TemplateRegistry, get_registry
 
 
 class TestTemplatePlugin:


### PR DESCRIPTION
## [0.2.0] - 2025-07-29

### Added
- **Plugin Architecture**: Implemented extensible plugin system for template management
  - Abstract `TemplatePlugin` base class for creating custom templates
  - `TemplateRegistry` for plugin discovery and management
  - Built-in plugin discovery for templates in `egile_mcp_starter/plugins/builtin/`
  - Support for external plugin registration
- **RAG Template**: New template for Retrieval-Augmented Generation (RAG) applications
  - Multiple vector database support: Chroma, Pinecone, Weaviate, Qdrant, FAISS
  - Multiple embedding models: Sentence Transformers, OpenAI, Cohere
  - Document processing capabilities (PDF, text, web scraping)
  - Configurable chunking strategies and retrieval methods
  - Advanced search capabilities with filtering and metadata
- **Enhanced CLI**: Extended command-line interface with template selection
  - `--template` option to choose between available templates (mcp, rag)
  - `--list-templates` option to display all available templates
  - Dynamic template validation and error handling
  - Improved help messages and user guidance
- **Comprehensive Documentation**: 
  - New `docs/templates.md` with plugin development guide
  - Updated README with streamlined content (reduced from 629 to 264 lines)
  - Template-specific documentation and examples
  - Plugin architecture best practices
- **Testing Suite**: Complete test coverage for plugin system
  - 28+ test methods covering all plugin functionality
  - Unit tests for template plugins, registry, and generator integration
  - Integration tests for end-to-end workflows
  - Mock-based testing for isolated component testing

### Changed
- **Generator Architecture**: Refactored `MCPProjectGenerator` to use plugin system
  - Template selection now handled through registry
  - Context generation delegated to template plugins
  - Backward compatibility maintained with original MCP template
- **Template Organization**: Restructured template system
  - Original template moved to `egile_mcp_starter/plugins/builtin/mcp_template.py`
  - New RAG template in `egile_mcp_starter/plugins/builtin/rag_template.py`
  - Template directories organized under `egile_mcp_starter/templates/`
- **Documentation Structure**: Reorganized documentation
  - Consolidated plugin architecture docs into main documentation
  - Integrated template information into README and docs

### Fixed
- CLI output formatting for project path handling
- Template path resolution in different environments
- Test compatibility with new plugin architecture
- Error handling for invalid template selections

### Technical Details
- Plugin system supports hooks for pre/post generation processing
- Template validation with customizable context requirements
- Dependency computation for RAG templates based on selected features
- Registry-based plugin discovery with automatic loading
- Comprehensive error handling and user-friendly messages
